### PR TITLE
fix: correctly passing URL through to auth during initialization

### DIFF
--- a/src/auth/index.js
+++ b/src/auth/index.js
@@ -128,7 +128,7 @@ export const fetchAuthenticatedUser = async () => {
  * @param {string} route to return user after login when not authenticated.
  * @returns {Promise<UserData>}
  */
-export const ensureAuthenticatedUser = async (route) => {
+export const ensureAuthenticatedUser = async (redirectUrl = config.appBaseUrl) => {
   await fetchAuthenticatedUser();
 
   if (getAuthenticatedUser() === null) {
@@ -142,7 +142,7 @@ export const ensureAuthenticatedUser = async (route) => {
     }
 
     // The user is not authenticated, send them to the login page.
-    redirectToLogin(config.appBaseUrl + route);
+    redirectToLogin(redirectUrl);
   }
 
   return getAuthenticatedUser();

--- a/src/auth/tests/AuthenticatedHttpClient.test.jsx
+++ b/src/auth/tests/AuthenticatedHttpClient.test.jsx
@@ -711,7 +711,7 @@ describe('ensureAuthenticatedUser', () => {
 
     it('attempts to refresh a missing jwt token and redirects user to login', () => {
       setJwtCookieTo(null);
-      return ensureAuthenticatedUser('/route').then((authenticatedUserAccessToken) => {
+      return ensureAuthenticatedUser(`${process.env.BASE_URL}/route`).then((authenticatedUserAccessToken) => {
         expect(authenticatedUserAccessToken).toBeNull();
         expectSingleCallToJwtTokenRefresh();
         expectLogin(`${process.env.BASE_URL}/route`);

--- a/src/i18n/index.js
+++ b/src/i18n/index.js
@@ -1,7 +1,6 @@
 export {
   intlShape,
   FormattedDate,
-  FormattedHTMLMessage,
   FormattedTime,
   FormattedRelative,
   FormattedNumber,

--- a/src/initialize.js
+++ b/src/initialize.js
@@ -29,7 +29,7 @@ export async function initError(error) {
 
 export async function auth(requireUser, hydrateUser) {
   if (requireUser) {
-    await ensureAuthenticatedUser();
+    await ensureAuthenticatedUser(global.location.href);
   } else {
     await fetchAuthenticatedUser();
   }


### PR DESCRIPTION
We weren’t passing the current URL through to ensureAuthenticatedUser during initialization, which meant that - if the user was logged out - we weren’t redirecting to the right page post-login.

Also removing FormattedHTMLMessage as an export - it was a mistake that it was available, as it’s not XSS safe.