### PR TITLE
export PageRoute and OptionalReduxProvider

### DIFF
--- a/src/react/index.js
+++ b/src/react/index.js
@@ -12,4 +12,6 @@ export { default as AuthenticatedPageRoute } from './AuthenticatedPageRoute';
 export { default as ErrorBoundary } from './ErrorBoundary';
 export { default as ErrorPage } from './ErrorPage';
 export { default as LoginRedirect } from './LoginRedirect';
+export { default as OptionalReduxProvider } from './OptionalReduxProvider';
+export { default as PageRoute } from './PageRoute';
 export { useAppEvent } from './hooks';

--- a/src/react/index.js
+++ b/src/react/index.js
@@ -12,6 +12,5 @@ export { default as AuthenticatedPageRoute } from './AuthenticatedPageRoute';
 export { default as ErrorBoundary } from './ErrorBoundary';
 export { default as ErrorPage } from './ErrorPage';
 export { default as LoginRedirect } from './LoginRedirect';
-export { default as OptionalReduxProvider } from './OptionalReduxProvider';
 export { default as PageRoute } from './PageRoute';
 export { useAppEvent } from './hooks';


### PR DESCRIPTION
Two of the React components in @edx/frontend-platform are not exported and currently unusable by a consuming application (the import comes back as undefined).

This PR ensures `PageRoute` and `OptionalReduxProvider` are exported.