### PR TITLE
fix: ceasing to throw errors on undefined config

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -4,6 +4,7 @@ BASE_URL=localhost:8080
 CREDENTIALS_BASE_URL=http://localhost:18150
 CSRF_TOKEN_API_PATH=/csrf/api/v1/token
 DISCOVERY_API_BASE_URL=http://localhost:18381
+PUBLISHER_BASE_URL=http://localhost:18400
 ECOMMERCE_BASE_URL=http://localhost:18130
 LANGUAGE_PREFERENCE_COOKIE_NAME=openedx-language-preference
 LMS_BASE_URL=http://localhost:18000

--- a/.env.test
+++ b/.env.test
@@ -4,6 +4,7 @@ BASE_URL=localhost:8080
 CREDENTIALS_BASE_URL=http://localhost:18150
 CSRF_TOKEN_API_PATH=/csrf/api/v1/token
 DISCOVERY_API_BASE_URL=http://localhost:18381
+PUBLISHER_BASE_URL=http://localhost:18400
 ECOMMERCE_BASE_URL=http://localhost:18130
 LANGUAGE_PREFERENCE_COOKIE_NAME=openedx-language-preference
 LMS_BASE_URL=http://localhost:18000

--- a/src/config.js
+++ b/src/config.js
@@ -38,6 +38,7 @@ let config = {
   CREDENTIALS_BASE_URL: process.env.CREDENTIALS_BASE_URL,
   CSRF_TOKEN_API_PATH: process.env.CSRF_TOKEN_API_PATH,
   DISCOVERY_API_BASE_URL: process.env.DISCOVERY_API_BASE_URL,
+  PUBLISHER_BASE_URL: process.env.PUBLISHER_BASE_URL,
   ECOMMERCE_BASE_URL: process.env.ECOMMERCE_BASE_URL,
   ENVIRONMENT,
   LANGUAGE_PREFERENCE_COOKIE_NAME: process.env.LANGUAGE_PREFERENCE_COOKIE_NAME,
@@ -88,7 +89,7 @@ export function setConfig(newConfig) {
  *   OTHER_NEW_KEY: 'other new value',
  * });
  *
- * If any of the key values are `undefined`, an error will be thrown.
+ * If any of the key values are `undefined`, an error will be logged to 'warn'.
  *
  * @param {Object} newConfig
  */
@@ -109,7 +110,7 @@ export function mergeConfig(newConfig) {
  * ```
  * ensureConfig(['LMS_BASE_URL', 'LOGIN_URL'], 'MySpecialComponent');
  *
- * // Will throw an error with:
+ * // Will log a warning with:
  * // "App configuration error: LOGIN_URL is required by MySpecialComponent."
  * // if LOGIN_URL is undefined, for example.
  * ```
@@ -126,7 +127,7 @@ export function ensureConfig(keys, requester = 'unspecified application code') {
   subscribe(APP_CONFIG_INITIALIZED, () => {
     keys.forEach((key) => {
       if (config[key] === undefined) {
-        throw new Error(`App configuration error: ${key} is required by ${requester}.`);
+        console.warn(`App configuration error: ${key} is required by ${requester}.`);
       }
     });
   });
@@ -155,6 +156,7 @@ export function ensureConfig(keys, requester = 'unspecified application code') {
  * @property {string} CREDENTIALS_BASE_URL
  * @property {string} CSRF_TOKEN_API_PATH
  * @property {string} DISCOVERY_API_BASE_URL
+ * @property {string} PUBLISHER_BASE_URL
  * @property {string} ECOMMERCE_BASE_URL
  * @property {string} ENVIRONMENT This is one of: development, production, or test.
  * @property {string} LANGUAGE_PREFERENCE_COOKIE_NAME

--- a/src/setupTest.js
+++ b/src/setupTest.js
@@ -13,6 +13,7 @@ process.env.BASE_URL = 'localhost:8080';
 process.env.CREDENTIALS_BASE_URL = 'http://localhost:18150';
 process.env.CSRF_TOKEN_API_PATH = '/csrf/api/v1/token';
 process.env.DISCOVERY_API_BASE_URL = 'http://localhost:18381';
+process.env.PUBLISHER_BASE_URL = 'http://localhost:18400';
 process.env.ECOMMERCE_BASE_URL = 'http://localhost:18130';
 process.env.LANGUAGE_PREFERENCE_COOKIE_NAME = 'openedx-language-preference';
 process.env.LMS_BASE_URL = 'http://localhost:18000';

--- a/src/utils.js
+++ b/src/utils.js
@@ -150,20 +150,18 @@ export function getQueryParameters(search = global.location.search) {
  * This function helps catch a certain class of misconfiguration in which configuration variables
  * are not properly defined and/or supplied to a consumer that requires them.  Any key that exists
  * is still set to "undefined" indicates a misconfiguration further up in the application, and
- * should be flagged as a fatal error.
+ * should be flagged as an error, and is logged to 'warn'.
  *
  * Keys that are intended to be falsy should be defined using null, 0, false, etc.
  *
  * @param {Object} object
  * @param {string} requester A human-readable identifier for the code which called this function.
  * Used when throwing errors to aid in debugging.
- *
- * @throws An error if any key in the objectToTest has a value of undefined.
  */
 export function ensureDefinedConfig(object, requester) {
   Object.keys(object).forEach((key) => {
     if (object[key] === undefined) {
-      throw new Error(`Module configuration error: ${key} is required by ${requester}.`);
+      console.warn(`Module configuration error: ${key} is required by ${requester}.`);
     }
   });
 }


### PR DESCRIPTION
Also adding PUBLISHER_BASE_URL to config.  Wanting to add this config made me realize that it was going to cause applications to start throwing errors on startup, since none of them would have PUBLISHER_BASE_URL defined yet.  That seems like an unaccpetable, dangerous outcome of changing the config variables which one wouldn’t expect to be a breaking change.

Fixes #70 by avoiding the problem.