### PR TITLE
WIP: Extend getConfig

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -59,10 +59,26 @@ let config = {
  * reference to an existing object, and is thus safe to call as often as desired.  The document
  * should have the following keys at a minimum:
  *
+ * If overloaded (to pass in at least a key, and optionally a fallback default value):
+ *   Find the first defined key/value in either config, process.env, or fall back to a default.
+ *
+ * @param {string} [key=undefined]
+ * @param {string} [fallback=undefined]
  * @returns {ConfigDocument}
   */
-export function getConfig() {
-  return config;
+export function getConfig(key=undefined, fallback=undefined) {
+  if (!key) {
+    return config;
+  }
+  let value = config[key];
+  if (value !== undefined) {
+    return value;
+  }
+  value = process.env[key];
+  if (value !== undefined) {
+    return value;
+  }
+  return fallback;
 }
 
 /**


### PR DESCRIPTION
to optionally lookup the value both in config now also check process.env .
An optional fallback/default can also be provided.

So the current use-case should still work, assuming you've exported the
ENV variable(s):

```js
const url = getConfig().URL;
const {
  URL,
} = getConfig();
```

This change also enables a key-based lookup that coalesces, looking for
the key in:
- config
- process.env

If still not _defined_ anywhere, it will fallback to a default value.

```js
const url = getConfig('URL');
const URL = getConfig('URL', 'localhost:18000');
```

[...]

In the future, this could be extended to check for the setting in a YAML file.