### PR TITLE
Set basename in order to allow the deployment of MFE in paths

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -24,17 +24,15 @@
  * @module Config
  */
 
-import { APP_CONFIG_INITIALIZED } from './initialize';
+import { APP_CONFIG_INITIALIZED, CONFIG_CHANGED } from './constants';
 import { publish, subscribe } from './pubSub';
 import { ensureDefinedConfig } from './utils';
-
-export const CONFIG_TOPIC = 'CONFIG';
-export const CONFIG_CHANGED = `${CONFIG_TOPIC}.CHANGED`;
 
 const ENVIRONMENT = process.env.NODE_ENV;
 let config = {
   ACCESS_TOKEN_COOKIE_NAME: process.env.ACCESS_TOKEN_COOKIE_NAME,
   BASE_URL: process.env.BASE_URL,
+  PUBLIC_PATH: process.env.PUBLIC_PATH || '/',
   CREDENTIALS_BASE_URL: process.env.CREDENTIALS_BASE_URL,
   CSRF_TOKEN_API_PATH: process.env.CSRF_TOKEN_API_PATH,
   DISCOVERY_API_BASE_URL: process.env.DISCOVERY_API_BASE_URL,

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,68 @@
+
+/** @constant */
+export const APP_TOPIC = 'APP';
+
+export const APP_PUBSUB_INITIALIZED = `${APP_TOPIC}.PUBSUB_INITIALIZED`;
+
+/**
+ * Event published when the application initialization sequence has finished loading any dynamic
+ * configuration setup in a custom config handler.
+ *
+ * @event
+ */
+export const APP_CONFIG_INITIALIZED = `${APP_TOPIC}.CONFIG_INITIALIZED`;
+
+/**
+ * Event published when the application initialization sequence has finished determining the user's
+ * authentication state, creating an authenticated API client, and executing auth handlers.
+ *
+ * @event
+ */
+export const APP_AUTH_INITIALIZED = `${APP_TOPIC}.AUTH_INITIALIZED`;
+
+/**
+ * Event published when the application initialization sequence has finished initializing
+ * internationalization and executing any i18n handlers.
+ *
+ * @event
+ */
+export const APP_I18N_INITIALIZED = `${APP_TOPIC}.I18N_INITIALIZED`;
+
+/**
+ * Event published when the application initialization sequence has finished initializing the
+ * logging service and executing any logging handlers.
+ *
+ * @event
+ */
+export const APP_LOGGING_INITIALIZED = `${APP_TOPIC}.LOGGING_INITIALIZED`;
+
+/**
+ * Event published when the application initialization sequence has finished initializing the
+ * analytics service and executing any analytics handlers.
+ *
+ * @event
+ */
+export const APP_ANALYTICS_INITIALIZED = `${APP_TOPIC}.ANALYTICS_INITIALIZED`;
+
+/**
+ * Event published when the application initialization sequence has finished.  Applications should
+ * subscribe to this event and start rendering the UI when it has fired.
+ *
+ * @event
+ */
+export const APP_READY = `${APP_TOPIC}.READY`;
+
+/**
+ * Event published when the application initialization sequence has aborted.  This is frequently
+ * used to show an error page when an initialization error has occurred.
+ *
+ * @see {@link module:React~ErrorPage}
+ * @event
+ */
+export const APP_INIT_ERROR = `${APP_TOPIC}.INIT_ERROR`;
+
+/** @constant */
+export const CONFIG_TOPIC = 'CONFIG';
+
+export const CONFIG_CHANGED = `${CONFIG_TOPIC}.CHANGED`;
+

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,6 @@ export {
   ensureDefinedConfig,
 } from './utils';
 export {
-  initialize,
   APP_TOPIC,
   APP_PUBSUB_INITIALIZED,
   APP_CONFIG_INITIALIZED,
@@ -17,6 +16,11 @@ export {
   APP_ANALYTICS_INITIALIZED,
   APP_READY,
   APP_INIT_ERROR,
+  CONFIG_TOPIC,
+  CONFIG_CHANGED,
+} from './constants';
+export {
+  initialize,
   history,
   initError,
   auth,
@@ -27,8 +31,6 @@ export {
   unsubscribe,
 } from './pubSub';
 export {
-  CONFIG_TOPIC,
-  CONFIG_CHANGED,
   getConfig,
   setConfig,
   mergeConfig,

--- a/src/initialize.js
+++ b/src/initialize.js
@@ -56,68 +56,7 @@ import { configure as configureLogging, getLoggingService, NewRelicLoggingServic
 import { configure as configureAnalytics, SegmentAnalyticsService, identifyAnonymousUser, identifyAuthenticatedUser } from './analytics';
 import { getAuthenticatedHttpClient, configure as configureAuth, ensureAuthenticatedUser, fetchAuthenticatedUser, hydrateAuthenticatedUser, getAuthenticatedUser, AxiosJwtAuthService } from './auth';
 import { configure as configureI18n } from './i18n';
-
-/** @constant */
-export const APP_TOPIC = 'APP';
-
-export const APP_PUBSUB_INITIALIZED = `${APP_TOPIC}.PUBSUB_INITIALIZED`;
-
-/**
- * Event published when the application initialization sequence has finished loading any dynamic
- * configuration setup in a custom config handler.
- *
- * @event
- */
-export const APP_CONFIG_INITIALIZED = `${APP_TOPIC}.CONFIG_INITIALIZED`;
-
-/**
- * Event published when the application initialization sequence has finished determining the user's
- * authentication state, creating an authenticated API client, and executing auth handlers.
- *
- * @event
- */
-export const APP_AUTH_INITIALIZED = `${APP_TOPIC}.AUTH_INITIALIZED`;
-
-/**
- * Event published when the application initialization sequence has finished initializing
- * internationalization and executing any i18n handlers.
- *
- * @event
- */
-export const APP_I18N_INITIALIZED = `${APP_TOPIC}.I18N_INITIALIZED`;
-
-/**
- * Event published when the application initialization sequence has finished initializing the
- * logging service and executing any logging handlers.
- *
- * @event
- */
-export const APP_LOGGING_INITIALIZED = `${APP_TOPIC}.LOGGING_INITIALIZED`;
-
-/**
- * Event published when the application initialization sequence has finished initializing the
- * analytics service and executing any analytics handlers.
- *
- * @event
- */
-export const APP_ANALYTICS_INITIALIZED = `${APP_TOPIC}.ANALYTICS_INITIALIZED`;
-
-/**
- * Event published when the application initialization sequence has finished.  Applications should
- * subscribe to this event and start rendering the UI when it has fired.
- *
- * @event
- */
-export const APP_READY = `${APP_TOPIC}.READY`;
-
-/**
- * Event published when the application initialization sequence has aborted.  This is frequently
- * used to show an error page when an initialization error has occurred.
- *
- * @see {@link module:React~ErrorPage}
- * @event
- */
-export const APP_INIT_ERROR = `${APP_TOPIC}.INIT_ERROR`;
+import { APP_PUBSUB_INITIALIZED, APP_CONFIG_INITIALIZED, APP_AUTH_INITIALIZED, APP_I18N_INITIALIZED, APP_LOGGING_INITIALIZED, APP_ANALYTICS_INITIALIZED, APP_READY, APP_INIT_ERROR } from './constants';
 
 /**
  * A browser history object created by the [history](https://github.com/ReactTraining/history)
@@ -125,7 +64,9 @@ export const APP_INIT_ERROR = `${APP_TOPIC}.INIT_ERROR`;
  * as behavior may be undefined when managing history via multiple mechanisms/instances.
  *
  */
-export const history = createBrowserHistory();
+export const history = createBrowserHistory({
+  basename: getConfig().PUBLIC_PATH,
+});
 
 /**
  * The default handler for the initialization lifecycle's `initError` phase.  Logs the error to the

--- a/src/initialize.test.js
+++ b/src/initialize.test.js
@@ -7,9 +7,9 @@ import {
   APP_ANALYTICS_INITIALIZED,
   APP_I18N_INITIALIZED,
   APP_READY,
-  initialize,
   APP_INIT_ERROR,
-} from './initialize';
+} from './constants';
+import { initialize } from './initialize';
 import { subscribe } from './pubSub';
 
 import { configure as configureLogging, NewRelicLoggingService, getLoggingService, logError } from './logging';

--- a/src/react/AppProvider.jsx
+++ b/src/react/AppProvider.jsx
@@ -8,7 +8,8 @@ import ErrorBoundary from './ErrorBoundary';
 import AppContext from './AppContext';
 import { useAppEvent } from './hooks';
 import { getAuthenticatedUser, AUTHENTICATED_USER_CHANGED } from '../auth';
-import { getConfig, CONFIG_CHANGED } from '../config';
+import { getConfig } from '../config';
+import { CONFIG_CHANGED } from '../constants';
 import { history } from '../initialize';
 import { getLocale, getMessages, IntlProvider, LOCALE_CHANGED } from '../i18n';
 


### PR DESCRIPTION
 For proper usage in the devstack are needed the changes from https://github.com/edx/frontend-build/pull/119 and from https://github.com/edx/frontend-build/pull/131

In this image I am serving the frontend-app-learning MFE in the devstack in the /learning/ path:

![image](https://user-images.githubusercontent.com/22335041/96513525-390fd080-1230-11eb-8f32-7c20ea8faee4.png)
