### PR TITLE
fix(auth): ensure app is refreshed after user hydration is complete

### DIFF
--- a/src/auth/MockAuthService.js
+++ b/src/auth/MockAuthService.js
@@ -225,7 +225,6 @@ class MockAuthService {
    * Sets the authenticated user to the provided value.
    *
    * @param {UserData} authUser
-   * @emits AUTHENTICATED_USER_CHANGED
    */
   setAuthenticatedUser(authUser) {
     this.authenticatedUser = authUser;

--- a/src/auth/interface.js
+++ b/src/auth/interface.js
@@ -238,10 +238,11 @@ export async function ensureAuthenticatedUser(redirectUrl) {
  *  console.log(authenticatedUser); // Will contain additional user information
  * ```
  *
- * @returns {Promise<null>}
+ * @emits AUTHENTICATED_USER_CHANGED
  */
 export async function hydrateAuthenticatedUser() {
-  return service.hydrateAuthenticatedUser();
+  await service.hydrateAuthenticatedUser();
+  publish(AUTHENTICATED_USER_CHANGED);
 }
 
 


### PR DESCRIPTION
There is a bug since, I believe, v1.4.0 where if the user's account should be hydrated (i.e., more user metadata fetched from an API), the app does not properly refresh once the hydration API request resolved.

This behavior can be seen in the `example` application within this repository.

This PR ensures the app is refreshed such that when the hydration API request resolves, the `authenticatedUser` has the additional user metadata as expected. It still does not block on rendering the app before the hydration API request resolves.

**Testing Instructions**
1. Checkout this branch locally: `astankiewicz/fix-user-hydration-reload`.
2. `npm install`, if necessary.
3. Start the example web app: `cd example && npm start`.
4. Observe the authenticated user's name appears after the hydration request is resolved.