### PR TITLE
Create SSR fallback for browser history in initialize.js

### DIFF
--- a/src/initialize.js
+++ b/src/initialize.js
@@ -45,7 +45,7 @@
  * @module Initialization
  */
 
-import { createBrowserHistory } from 'history';
+import { createBrowserHistory, createMemoryHistory } from 'history';
 import {
   publish,
 } from './pubSub';
@@ -126,7 +126,7 @@ export const APP_INIT_ERROR = `${APP_TOPIC}.INIT_ERROR`;
  * environments where browser history may be inaccessible due to `window` being undefined, this falls back to
  * memory history.
  */
-export var history = (typeof window !== 'undefined') ? createBrowserHistory() : createMemoryHistory();
+export const history = (typeof window !== 'undefined') ? createBrowserHistory() : createMemoryHistory();
 
 /**
  * The default handler for the initialization lifecycle's `initError` phase.  Logs the error to the

--- a/src/initialize.js
+++ b/src/initialize.js
@@ -120,12 +120,13 @@ export const APP_READY = `${APP_TOPIC}.READY`;
 export const APP_INIT_ERROR = `${APP_TOPIC}.INIT_ERROR`;
 
 /**
- * A browser history object created by the [history](https://github.com/ReactTraining/history)
+ * A browser history or memory history object created by the [history](https://github.com/ReactTraining/history)
  * package.  Applications are encouraged to use this history object, rather than creating their own,
- * as behavior may be undefined when managing history via multiple mechanisms/instances.
- *
+ * as behavior may be undefined when managing history via multiple mechanisms/instances. Note that in
+ * environments where browser history may be inaccessible due to `window` being undefined, this falls back to
+ * memory history.
  */
-export const history = createBrowserHistory();
+export var history = (typeof window !== 'undefined') ? createBrowserHistory() : createMemoryHistory();
 
 /**
  * The default handler for the initialization lifecycle's `initError` phase.  Logs the error to the

--- a/src/initialize.js
+++ b/src/initialize.js
@@ -122,9 +122,9 @@ export const APP_INIT_ERROR = `${APP_TOPIC}.INIT_ERROR`;
 /**
  * A browser history or memory history object created by the [history](https://github.com/ReactTraining/history)
  * package.  Applications are encouraged to use this history object, rather than creating their own,
- * as behavior may be undefined when managing history via multiple mechanisms/instances. Note that in
- * environments where browser history may be inaccessible due to `window` being undefined, this falls back to
- * memory history.
+ * as behavior may be undefined when managing history via multiple mechanisms/instances. Note that
+ * in environments where browser history may be inaccessible due to `window` being undefined, this
+ * falls back to memory history.
  */
 export const history = (typeof window !== 'undefined') ? createBrowserHistory() : createMemoryHistory();
 
@@ -186,7 +186,7 @@ export async function analytics() {
 }
 
 function applyOverrideHandlers(overrides) {
-  const noOp = async () => {};
+  const noOp = async () => { };
   return {
     pubSub: noOp,
     config: noOp,

--- a/src/initialize.js
+++ b/src/initialize.js
@@ -65,7 +65,7 @@ import { APP_PUBSUB_INITIALIZED, APP_CONFIG_INITIALIZED, APP_AUTH_INITIALIZED, A
  * in environments where browser history may be inaccessible due to `window` being undefined, this
  * falls back to memory history.
  */
-export const history = (typeof window !== 'undefined') ? 
+export const history = (typeof window !== 'undefined') ?
   createBrowserHistory({
     basename: getConfig().PUBLIC_PATH,
   }) : createMemoryHistory();


### PR DESCRIPTION
attn @davidjoy 👍 

This is a workaround to enable this libaray's use on Gatsby-based sites which use `@edx/frontend-platform`.  

# Why this change
When building a production site, Gatsby makes a pass over all URLs for the site to do server side rendering, at which point it doesn't have access to `window` and other browser APIs, so calling `createBrowserHistory()` throws an exception.  This was happening when running `gatsby build` for deploys of our gatsby-based site for Gymnasium ([link](https://app.netlify.com/sites/gymnasium-gatsby/deploys/5f88ae1ae2169e0007996e02)).

# The workaround 
When `window` doesnt' exist, the library falls back to creating a [`memoryHistory` object](https://github.com/ReactTraining/history/blob/master/docs/api-reference.md#creatememoryhistory), which is another implementation of the same interface from the `history` library.  This works in SSR during build, and should revert to using `browserHistory` on client-side page loads.
