### PR TITLE
feat: add logo URLs to AppContext config

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -17,3 +17,7 @@ REFRESH_ACCESS_TOKEN_ENDPOINT=http://localhost:18000/login_refresh
 SEGMENT_KEY=ul
 SITE_NAME=Open edX
 USER_INFO_COOKIE_NAME=edx-user-info
+LOGO_URL=https://edx-cdn.org/v3/default/logo.svg
+LOGO_TRADEMARK_URL=https://edx-cdn.org/v3/default/logo-trademark.svg
+LOGO_WHITE_URL=https://edx-cdn.org/v3/default/logo-white.svg
+FAVICON_URL=https://edx-cdn.org/v3/default/favicon.ico

--- a/.env.test
+++ b/.env.test
@@ -17,3 +17,7 @@ REFRESH_ACCESS_TOKEN_ENDPOINT=http://localhost:18000/login_refresh
 SEGMENT_KEY=ul
 SITE_NAME=Open edX
 USER_INFO_COOKIE_NAME=edx-user-info
+LOGO_URL=https://edx-cdn.org/v3/default/logo.svg
+LOGO_TRADEMARK_URL=https://edx-cdn.org/v3/default/logo-trademark.svg
+LOGO_WHITE_URL=https://edx-cdn.org/v3/default/logo-white.svg
+FAVICON_URL=https://edx-cdn.org/v3/default/favicon.ico

--- a/src/config.js
+++ b/src/config.js
@@ -176,4 +176,8 @@ export function ensureConfig(keys, requester = 'unspecified application code') {
  * @property {string} SEGMENT_KEY
  * @property {string} SITE_NAME
  * @property {string} USER_INFO_COOKIE_NAME
+ * @property {string} LOGO_URL
+ * @property {string} LOGO_TRADEMARK_URL
+ * @property {string} LOGO_WHITE_URL
+ * @property {string} FAVICON_URL
  */

--- a/src/config.js
+++ b/src/config.js
@@ -52,6 +52,10 @@ let config = {
   SEGMENT_KEY: process.env.SEGMENT_KEY,
   SITE_NAME: process.env.SITE_NAME,
   USER_INFO_COOKIE_NAME: process.env.USER_INFO_COOKIE_NAME,
+  LOGO_URL: process.env.LOGO_URL,
+  LOGO_TRADEMARK_URL: process.env.LOGO_TRADEMARK_URL,
+  LOGO_WHITE_URL: process.env.LOGO_WHITE_URL,
+  FAVICON_URL: process.env.FAVICON_URL,
 };
 
 /**

--- a/src/setupTest.js
+++ b/src/setupTest.js
@@ -26,6 +26,10 @@ process.env.REFRESH_ACCESS_TOKEN_ENDPOINT = 'http://localhost:18000/login_refres
 process.env.SEGMENT_KEY = 'segment_whoa';
 process.env.SITE_NAME = 'edX';
 process.env.USER_INFO_COOKIE_NAME = 'edx-user-info';
+process.env.LOGO_URL = 'https://edx-cdn.org/v3/default/logo.svg';
+process.env.LOGO_TRADEMARK_URL = 'https://edx-cdn.org/v3/default/logo-trademark.svg';
+process.env.LOGO_WHITE_URL = 'https://edx-cdn.org/v3/default/logo-white.svg';
+process.env.FAVICON_URL = 'https://edx-cdn.org/v3/default/favicon.ico';
 
 /* Auth test variables
 


### PR DESCRIPTION
Adds the following settings to the default configuration object:
* `LOGO_URL`
* `LOGO_TRADEMARK_URL`
* `LOGO_WHITE_URL`
* `FAVICON_URL`

This is needed for these configuration settings to be available through @edx/frontend-platform's `getConfig()`.