### PR TITLE
feat: Adds initializeMockApp for component testing

### DIFF
--- a/src/analytics/MockAnalyticsService.js
+++ b/src/analytics/MockAnalyticsService.js
@@ -1,7 +1,7 @@
-import formurlencoded from 'form-urlencoded';
-import { snakeCaseObject } from '../utils';
-
 /**
+ * The MockAnalyticsService implements all functions of AnalyticsService with Jest mocks, i.e.,
+ * jest.fn().  It has no other functionality.
+ *
  * @implements {AnalyticsService}
  * @memberof module:Analytics
  */

--- a/src/analytics/MockAnalyticsService.js
+++ b/src/analytics/MockAnalyticsService.js
@@ -1,0 +1,42 @@
+import formurlencoded from 'form-urlencoded';
+import { snakeCaseObject } from '../utils';
+
+/**
+ * @implements {AnalyticsService}
+ * @memberof module:Analytics
+ */
+class MockAnalyticsService {
+  static hasIdentifyBeenCalled = false;
+
+  constructor({ httpClient, loggingService }) {
+    this.loggingService = loggingService;
+    this.httpClient = httpClient;
+  }
+
+  /**
+   * Implemented as a jest.fn().
+   */
+  sendTrackingLogEvent = jest.fn();
+
+  /**
+   * Implemented as a jest.fn().
+   */
+  identifyAuthenticatedUser = jest.fn();
+
+  /**
+   * Implemented as a jest.fn().
+   */
+  identifyAnonymousUser = jest.fn();
+
+  /**
+   * Implemented as a jest.fn().
+   */
+  sendTrackEvent = jest.fn();
+
+  /**
+   * Implemented as a jest.fn().
+   */
+  sendPageEvent = jest.fn();
+}
+
+export default MockAnalyticsService;

--- a/src/analytics/index.js
+++ b/src/analytics/index.js
@@ -9,3 +9,4 @@ export {
   resetAnalyticsService,
 } from './interface';
 export { default as SegmentAnalyticsService } from './SegmentAnalyticsService';
+export { default as MockAnalyticsService } from './MockAnalyticsService';

--- a/src/analytics/interface.js
+++ b/src/analytics/interface.js
@@ -29,9 +29,7 @@ import PropTypes from 'prop-types';
 
 const optionsShape = {
   config: PropTypes.object.isRequired,
-  httpClient: PropTypes.shape({
-    post: PropTypes.func.isRequired,
-  }).isRequired,
+  httpClient: PropTypes.func.isRequired,
   loggingService: PropTypes.shape({
     logError: PropTypes.func.isRequired,
     logInfo: PropTypes.func.isRequired,

--- a/src/analytics/interface.test.js
+++ b/src/analytics/interface.test.js
@@ -20,9 +20,11 @@ const mockLoggingService = {
   logError: jest.fn(),
   logInfo: jest.fn(),
 };
-const mockAuthApiClient = {
-  post: jest.fn().mockResolvedValue(undefined),
+// The actual ApiClient is a function, so while this feels weird, it accurately models the real
+// thing.
+const mockAuthApiClient = () => {
 };
+mockAuthApiClient.post = jest.fn().mockResolvedValue(undefined);
 
 // SegmentAnalyticsService inserts a script before the first script element
 // in the document. Add one here.

--- a/src/auth/index.js
+++ b/src/auth/index.js
@@ -3,6 +3,7 @@ export {
   AUTHENTICATED_USER_CHANGED,
   configure,
   getAuthenticatedHttpClient,
+  getAuthService,
   getHttpClient,
   getLoginRedirectUrl,
   redirectToLogin,

--- a/src/index.js
+++ b/src/index.js
@@ -36,3 +36,7 @@ export {
   mergeConfig,
   ensureConfig,
 } from './config';
+export {
+  initializeMockApp,
+  mockMessages,
+} from './testing';

--- a/src/logging/MockLoggingService.js
+++ b/src/logging/MockLoggingService.js
@@ -1,0 +1,24 @@
+/**
+ * The MockLoggingService implements both logInfo and logError as jest mock functions via
+ * jest.fn().  It has no other functionality.
+ *
+ * @implements {LoggingService}
+ * @memberof module:Logging
+ */
+class MockLoggingService {
+  /**
+   * Implemented as a jest.fn()
+   *
+   * @memberof MockLoggingService
+   */
+  logInfo = jest.fn();
+
+  /**
+   * Implemented as a jest.fn()
+   *
+   * @memberof MockLoggingService
+   */
+  logError = jest.fn();
+}
+
+export default MockLoggingService;

--- a/src/logging/index.js
+++ b/src/logging/index.js
@@ -6,3 +6,4 @@ export {
   logError,
 } from './interface';
 export { default as NewRelicLoggingService } from './NewRelicLoggingService';
+export { default as MockLoggingService } from './MockLoggingService';

--- a/src/testing/index.js
+++ b/src/testing/index.js
@@ -1,1 +1,2 @@
+// eslint-disable-next-line import/prefer-default-export
 export { default as initializeMockApp } from './initializeMockApp';

--- a/src/testing/index.js
+++ b/src/testing/index.js
@@ -1,3 +1,9 @@
-// eslint-disable-next-line import/prefer-default-export
+/**
+ * #### Import members from **@edx/frontend-platform/testing**
+ * The testing module provides helpers for writing tests in Jest.
+ *
+ * @module Testing
+ */
+
 export { default as initializeMockApp } from './initializeMockApp';
 export { default as mockMessages } from './mockMessages';

--- a/src/testing/index.js
+++ b/src/testing/index.js
@@ -1,2 +1,3 @@
 // eslint-disable-next-line import/prefer-default-export
 export { default as initializeMockApp } from './initializeMockApp';
+export { default as mockMessages } from './mockMessages';

--- a/src/testing/index.js
+++ b/src/testing/index.js
@@ -1,0 +1,1 @@
+export { default as initializeMockApp } from './initializeMockApp';

--- a/src/testing/initializeMockApp.js
+++ b/src/testing/initializeMockApp.js
@@ -1,0 +1,59 @@
+import { configure as configureAnalytics, MockAnalyticsService } from '../analytics';
+import { configure as configureI18n } from '../i18n';
+import { configure as configureLogging, MockLoggingService } from '../logging';
+import { configure as configureAuth, MockAuthService } from '../auth';
+import { getConfig } from '../config';
+
+/**
+ * Initializes a mock application for component testing. The mock application includes
+ * mock analytics, auth, and logging services, and the real i18n service.
+ *
+ * See MockAnalyticsService, MockAuthService, and MockLoggingService for mock implementation
+ * details. For the most part, the analytics and logging services just implement their functions
+ * with jest.fn() and do nothing else, whereas the MockAuthService actually has some behavior
+ * implemented, it just doesn't make any HTTP calls.
+ *
+ * Note that this mock application is not sufficient for testing the full application lifecycle or
+ * initialization callbacks/custom handlers as described in the 'initialize' function's
+ * documentation. It exists merely to set up the mock services that components themselves tend to
+ * interact with most often. It could be extended to allow for setting up custom handlers fairly
+ * easily, as this functionality would be more-or-less identical to what the real initialize
+ * function does.
+ *
+ * @param {Object} [options]
+ * @param {*} [options.messages] A i18n-compatible messages object, or an array of such objects. If
+ * an array is provided, duplicate keys are resolved with the last-one-in winning.
+ * @param {UserData|null} [options.authenticatedUser] A UserData object representing the
+ * authenticated user. This is passed directly to MockAuthService.
+ */
+export default function initializeMockApp({
+  messages = {},
+  authenticatedUser = null,
+}) {
+  const loggingService = configureLogging(MockLoggingService, {
+    config: getConfig(),
+  });
+
+  const authService = configureAuth(MockAuthService, {
+    config: { ...getConfig(), authenticatedUser },
+    loggingService,
+  });
+
+  const analyticsService = configureAnalytics(MockAnalyticsService, {
+    httpClient: authService.getAuthenticatedHttpClient(),
+    loggingService,
+  });
+
+  const i18nService = configureI18n({
+    config: getConfig(),
+    loggingService,
+    messages,
+  });
+
+  return {
+    analyticsService,
+    authService,
+    i18nService,
+    loggingService,
+  };
+}

--- a/src/testing/initializeMockApp.js
+++ b/src/testing/initializeMockApp.js
@@ -21,11 +21,27 @@ import mockMessages from './mockMessages';
  * easily, as this functionality would be more-or-less identical to what the real initialize
  * function does.
  *
+ * Example:
+ *
+ * ```
+ * import { initializeMockApp } from '@edx/frontend-platform/testing';
+ * import { logInfo } from '@edx/frontend-platform/logging';
+ *
+ * describe('initializeMockApp', () => {
+ *   it('mocks things correctly', () => {
+ *     const { loggingService } = initializeMockApp();
+ *     logInfo('test', {});
+ *     expect(loggingService.logInfo).toHaveBeenCalledWith('test', {});
+ *   });
+ * });
+ * ```
+ *
  * @param {Object} [options]
  * @param {*} [options.messages] A i18n-compatible messages object, or an array of such objects. If
  * an array is provided, duplicate keys are resolved with the last-one-in winning.
  * @param {UserData|null} [options.authenticatedUser] A UserData object representing the
  * authenticated user. This is passed directly to MockAuthService.
+ * @memberof module:Testing
  */
 export default function initializeMockApp({
   messages = mockMessages,

--- a/src/testing/initializeMockApp.js
+++ b/src/testing/initializeMockApp.js
@@ -3,6 +3,7 @@ import { configure as configureI18n } from '../i18n';
 import { configure as configureLogging, MockLoggingService } from '../logging';
 import { configure as configureAuth, MockAuthService } from '../auth';
 import { getConfig } from '../config';
+import mockMessages from './mockMessages';
 
 /**
  * Initializes a mock application for component testing. The mock application includes
@@ -27,9 +28,9 @@ import { getConfig } from '../config';
  * authenticated user. This is passed directly to MockAuthService.
  */
 export default function initializeMockApp({
-  messages = {},
+  messages = mockMessages,
   authenticatedUser = null,
-}) {
+} = {}) {
   const loggingService = configureLogging(MockLoggingService, {
     config: getConfig(),
   });
@@ -40,11 +41,13 @@ export default function initializeMockApp({
   });
 
   const analyticsService = configureAnalytics(MockAnalyticsService, {
+    config: getConfig(),
     httpClient: authService.getAuthenticatedHttpClient(),
     loggingService,
   });
 
-  const i18nService = configureI18n({
+  // The i18n service configure function has no return value, since there isn't a service class.
+  configureI18n({
     config: getConfig(),
     loggingService,
     messages,
@@ -53,7 +56,6 @@ export default function initializeMockApp({
   return {
     analyticsService,
     authService,
-    i18nService,
     loggingService,
   };
 }

--- a/src/testing/initializeMockApp.test.js
+++ b/src/testing/initializeMockApp.test.js
@@ -1,0 +1,65 @@
+import initializeMockApp from './initializeMockApp';
+import {
+  getAnalyticsService,
+  MockAnalyticsService,
+  sendTrackEvent,
+} from '../analytics';
+import {
+  MockAuthService,
+  ensureAuthenticatedUser,
+  getAuthService,
+  getLoginRedirectUrl,
+  setAuthenticatedUser,
+} from '../auth';
+import {
+  getLoggingService,
+  logInfo,
+  MockLoggingService,
+} from '../logging';
+
+describe('initializeMockApp', () => {
+  it('should create mock analytics, auth, and logging services, and a real i18n service', () => {
+    const {
+      analyticsService,
+      authService,
+      loggingService,
+    } = initializeMockApp();
+
+    expect(getAnalyticsService()).toBeInstanceOf(MockAnalyticsService);
+    expect(getAuthService()).toBeInstanceOf(MockAuthService);
+    expect(getLoggingService()).toBeInstanceOf(MockLoggingService);
+
+    const customAttributes = { custom: 'attribute' };
+
+    // Next, test a representative sample of functionality to prove mocking is working the way we hope.
+
+    // Analytics
+    sendTrackEvent('testEvent', customAttributes);
+    expect(analyticsService.sendTrackEvent).toHaveBeenCalledWith('testEvent', customAttributes);
+    // The mock analytics service calls checkIdentifyCalled when sendTrackEvent is called.  Prove
+    // the jest.fn() works.
+    expect(analyticsService.checkIdentifyCalled).toHaveBeenCalledTimes(1);
+
+    // Auth
+    getLoginRedirectUrl('http://localhost/redirect/url');
+    setAuthenticatedUser({
+      userId: 'abc123',
+      username: 'Mock User',
+      roles: [],
+      administrator: false,
+    });
+    ensureAuthenticatedUser();
+
+    expect(authService.getLoginRedirectUrl).toHaveBeenCalledWith('http://localhost/redirect/url');
+    expect(authService.ensureAuthenticatedUser).toHaveBeenCalled();
+    // ensureAuthenticatedUser calls a few other things under the covers.  Prove our mocking is
+    // working as expected across multiple levels.
+    expect(authService.fetchAuthenticatedUser).toHaveBeenCalled();
+    expect(authService.getAuthenticatedUser).toHaveBeenCalled();
+    expect(authService.redirectToLogin).not.toHaveBeenCalled();
+
+    // Logging
+    logInfo('logging info', customAttributes);
+    expect(loggingService.logInfo).toHaveBeenCalledWith('logging info', customAttributes);
+  });
+});

--- a/src/testing/mockMessages.js
+++ b/src/testing/mockMessages.js
@@ -1,0 +1,20 @@
+/**
+ * An empty messages object suitable for fulfilling the i18n service's contract.
+ */
+const messages = {
+  ar: {},
+  'es-419': {},
+  fr: {},
+  'zh-cn': {},
+  ca: {},
+  he: {},
+  id: {},
+  'ko-kr': {},
+  pl: {},
+  'pt-br': {},
+  ru: {},
+  th: {},
+  uk: {},
+};
+
+export default messages;

--- a/src/testing/mockMessages.js
+++ b/src/testing/mockMessages.js
@@ -1,5 +1,6 @@
 /**
  * An empty messages object suitable for fulfilling the i18n service's contract.
+ * @memberof module:Testing
  */
 const messages = {
   ar: {},


### PR DESCRIPTION
The initializeMockApp function will setup mock versions of the analytics, auth, and logging services, see function description for more details.  The i18n service is set up as normal, since it makes no requests and is suitable for tests.

Using this should save a a bunch of manual test setup to mock logging/analytics calls and set up mock HTTP clients.

```
import { initializeMockApp } from '@edx/frontend-platform/testing';
import { logInfo } from '@edx/frontend-platform/logging';

describe('initializeMockApp', () => {
  it('mocks things correctly', () => {
    const { loggingService } = initializeMockApp();
    logInfo('wut', {});
    expect(loggingService.logInfo).toHaveBeenCalledWith('wut', {});
  });
});

```
