### PR TITLE
fix: set the paragon peer dep to 12.8.0 to <14.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "universal-cookie": "4.0.4"
   },
   "peerDependencies": {
-    "@edx/paragon": "^12.8.0",
+    "@edx/paragon": ">=12.8.0 <14.0.0",
     "prop-types": "^15.7.2",
     "react": "^16.9.0",
     "react-dom": "^16.9.0",


### PR DESCRIPTION
We’re seeing issues in MFEs running paragon 13 where they can’t build in GoCD.

See version range rules here: https://docs.npmjs.com/cli/v6/using-npm/semver