### PR TITLE
draft: feat: Log errors as Info if they are in QUIET_ERROR_REGEXES

### DIFF
--- a/src/react/ErrorBoundary.jsx
+++ b/src/react/ErrorBoundary.jsx
@@ -1,9 +1,19 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
-import { logError } from '../logging';
+import { logError, logInfo } from '../logging';
+import { getConfig } from '../config';
 
 import ErrorPage from './ErrorPage';
+
+function shouldQuietError(error) {
+  if (!('QUIET_ERROR_REGEXES' in getConfig())) {
+    return false;
+  }
+  const quietErrorRegexes = getConfig().QUIET_ERROR_REGEXES.split(';');
+  const errorString = error.toString();
+  return quietErrorRegexes.some(regex => regex.matches(errorString));
+}
 
 /**
  * Error boundary component used to log caught errors and display the error page.
@@ -23,7 +33,8 @@ export default class ErrorBoundary extends Component {
   }
 
   componentDidCatch(error, info) {
-    logError(error, { stack: info.componentStack });
+    const log = shouldQuietError(error) ? logInfo : logError;
+    log(error, { stack: info.componentStack });
   }
 
   render() {


### PR DESCRIPTION
Just looking for initial feedback on this idea right now. This still needs tests and comments.

The idea is that individual MFEs could configure a list of `QUIET_ERROR_REGEXES`, delimited by semicolons (I considered comma-delimited, but that seems more likely to clash with regexes that folks might want to write. Maybe double-semicolons would be an even stronger delimiter?). If an error message matches any of these regexes, it will be passed to `logInfo` instead of `logError`.

Related to [TNL-7924](https://openedx.atlassian.net/browse/TNL-7924)