### PR TITLE
fix: AA-513: Reset segment state if anon user and there is a segment user id

### DIFF
--- a/src/analytics/SegmentAnalyticsService.js
+++ b/src/analytics/SegmentAnalyticsService.js
@@ -153,10 +153,34 @@ class SegmentAnalyticsService {
    * Send anonymous identify call to Segment's identify.
    *
    * @param {*} [traits]
+   * @returns {Promise} Promise that will resolve once the document readyState is complete
    */
   identifyAnonymousUser(traits) {
-    global.analytics.identify(traits);
-    this.hasIdentifyBeenCalled = true;
+    // if we do not have an authenticated user (indicated by being in this method),
+    // but we still have a user id associated in segment, reset the local segment state
+    // This has to be wrapped in the document.readyState logic because the analytics.user()
+    // function isn't available until the analytics.js package has finished initializing.
+    return new Promise((resolve, reject) => { // eslint-disable-line no-unused-vars
+      if (document.readyState === 'complete') {
+        if (global.analytics.user().id()) {
+          global.analytics.reset();
+        }
+        global.analytics.identify(traits);
+        this.hasIdentifyBeenCalled = true;
+        resolve();
+      } else {
+        document.addEventListener('readystatechange', event => {
+          if (event.target.readyState === 'complete') {
+            if (global.analytics.user().id()) {
+              global.analytics.reset();
+            }
+            global.analytics.identify(traits);
+            this.hasIdentifyBeenCalled = true;
+            resolve();
+          }
+        });
+      }
+    });
   }
 
   /**

--- a/src/analytics/interface.js
+++ b/src/analytics/interface.js
@@ -85,9 +85,10 @@ export function identifyAuthenticatedUser(userId, traits) {
  *
  *
  * @param {*} traits
+ * @returns {Promise}
  */
 export function identifyAnonymousUser(traits) {
-  service.identifyAnonymousUser(traits);
+  return service.identifyAnonymousUser(traits);
 }
 
 /**

--- a/src/analytics/interface.test.js
+++ b/src/analytics/interface.test.js
@@ -43,6 +43,7 @@ beforeEach(() => {
   window.analytics.identify = jest.fn();
   window.analytics.page = jest.fn();
   window.analytics.track = jest.fn();
+  window.analytics.reset = jest.fn();
 });
 
 describe('analytics sendTrackingLogEvent', () => {
@@ -86,10 +87,22 @@ describe('analytics identifyAuthenticatedUser', () => {
 });
 
 describe('analytics identifyAnonymousUser', () => {
-  it('calls Segment identify on success', () => {
+  it('calls Segment identify on success - no previous segment user', () => {
+    window.analytics.user = () => ({ id: () => null });
     const testTraits = { anything: 'Yay!' };
     identifyAnonymousUser(testTraits);
 
+    expect(window.analytics.reset.mock.calls.length).toBe(0);
+    expect(window.analytics.identify.mock.calls.length).toBe(1);
+    expect(window.analytics.identify).toBeCalledWith(testTraits);
+  });
+
+  it('calls Segment identify on success - previous segment user', () => {
+    window.analytics.user = () => ({ id: () => 7 });
+    const testTraits = { anything: 'Yay!' };
+    identifyAnonymousUser(testTraits);
+
+    expect(window.analytics.reset.mock.calls.length).toBe(1);
     expect(window.analytics.identify.mock.calls.length).toBe(1);
     expect(window.analytics.identify).toBeCalledWith(testTraits);
   });

--- a/src/initialize.js
+++ b/src/initialize.js
@@ -141,7 +141,7 @@ export async function analytics() {
   if (authenticatedUser && authenticatedUser.userId) {
     identifyAuthenticatedUser(authenticatedUser.userId);
   } else {
-    identifyAnonymousUser();
+    await identifyAnonymousUser();
   }
 }
 


### PR DESCRIPTION
If we are seeing an anonymous user, but the segment user id is still
set, we believe the segment user id is coming from a different user on
the same machine. This will make sure we clear out that storage and
then the indentify call will make a new anonymous id