### PR TITLE
fix: correct examples according to defined params

### DIFF
--- a/example/ExamplePage.jsx
+++ b/example/ExamplePage.jsx
@@ -7,13 +7,13 @@ import { AppContext } from '@edx/frontend-platform/react';
 import { ensureConfig, mergeConfig, getConfig } from '@edx/frontend-platform';
 import messages from './messages';
 
-ensureConfig([
-  'EXAMPLE_VAR',
-]);
-
 mergeConfig({
   EXAMPLE_VAR: process.env.EXAMPLE_VAR,
-}, 'ExamplePage');
+});
+
+ensureConfig([
+  'EXAMPLE_VAR',
+], 'ExamplePage');
 
 class ExamplePage extends Component {
   constructor(props, context) {


### PR DESCRIPTION
`ensureConfig` and `mergeConfig` were called with incorrect params, this PR fixes the order and call them accordingly. 

Please refer to https://github.com/edx/frontend-platform/blob/master/src/config.js for correct function params