### PR TITLE
fix: prevent duplicate page view events from being dispatched

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,3 @@ coverage
 dist
 node_modules
 /docs/api
-

--- a/src/react/PageRoute.jsx
+++ b/src/react/PageRoute.jsx
@@ -22,7 +22,8 @@ export default function PageRoute(props) {
     if (match) {
       sendPageEvent();
     }
-  }, [match]);
+  }, [JSON.stringify(match)]);
+
   return (
     <Route {...props} />
   );


### PR DESCRIPTION
Currently, we are dispatching twice as many page view events as we should be for any MFE that uses the `PageRoute` or `AuthenticatedPageRoute` components for routing. That is, for every real page view event, we are currently dispatching a second duplicate event. This adds lot of noise to our analytics and limits the validity of any page view based metrics.

The `useEffect` that controls dispatching a page event to Segment is executed whenever the the `match` object changes its reference without actually changing any of its values, e.g.:

```js
const match1 = { a: 2, b: 5 };
const match2 = { a: 2, b: 5 };

console.log(match1 == match2); // false
console.log(match1 === match2); // false
```

Due to this, we are sending erroneous page view events. Instead, stringifying the `match` object will only execute the effect when the _values_ of the match object actually change, not when the reference to the object changes.