### PR TITLE
fix: Guard against a missing IGNORED_ERROR_REGEX environment variable.

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -29,6 +29,15 @@ import { APP_CONFIG_INITIALIZED, CONFIG_CHANGED } from './constants';
 import { publish, subscribe } from './pubSub';
 import { ensureDefinedConfig } from './utils';
 
+function extractRegex(envVar) {
+  // Convert the environment variable string to a regex, while guarding
+  // against a non-string and an empty/whitespace-only string.
+  if (typeof envVar === 'string' && envVar.trim() !== '') {
+    return new RegExp(envVar);
+  }
+  return undefined;
+}
+
 const ENVIRONMENT = process.env.NODE_ENV;
 let config = {
   ACCESS_TOKEN_COOKIE_NAME: process.env.ACCESS_TOKEN_COOKIE_NAME,
@@ -40,8 +49,7 @@ let config = {
   PUBLISHER_BASE_URL: process.env.PUBLISHER_BASE_URL,
   ECOMMERCE_BASE_URL: process.env.ECOMMERCE_BASE_URL,
   ENVIRONMENT,
-  // Convert the ignored errors regex string to a regex, guarding against an empty string.
-  IGNORED_ERROR_REGEX: process.env.IGNORED_ERROR_REGEX.trim() === '' ? undefined : new RegExp(process.env.IGNORED_ERROR_REGEX),
+  IGNORED_ERROR_REGEX: extractRegex(process.env.IGNORED_ERROR_REGEX),
   LANGUAGE_PREFERENCE_COOKIE_NAME: process.env.LANGUAGE_PREFERENCE_COOKIE_NAME,
   LMS_BASE_URL: process.env.LMS_BASE_URL,
   LOGIN_URL: process.env.LOGIN_URL,

--- a/src/logging/NewRelicLoggingService.js
+++ b/src/logging/NewRelicLoggingService.js
@@ -74,7 +74,7 @@ function sendError(error, customAttributes) {
  */
 export default class NewRelicLoggingService {
   constructor(options) {
-    this.config = options ? options.config : undefined;
+    const config = options ? options.config : undefined;
     /*
         String which is an explicit error message regex. If an error message matches the regex, the error
         is considered an *ignored* error and submitted to New Relic as a page action - not an error.
@@ -103,7 +103,7 @@ export default class NewRelicLoggingService {
 
         For edx.org, add new error message regexes in edx-internal YAML as needed.
     */
-    this.ignoredErrorRegexes = (this.config && 'IGNORED_ERROR_REGEX' in this.config) ? this.config.IGNORED_ERROR_REGEX : undefined;
+    this.ignoredErrorRegexes = config ? config.IGNORED_ERROR_REGEX : undefined;
   }
 
   /**

--- a/src/logging/NewRelicLoggingService.test.js
+++ b/src/logging/NewRelicLoggingService.test.js
@@ -16,6 +16,16 @@ const configWithNullIgnoredErrors = {
     IGNORED_ERROR_REGEX: null,
   },
 };
+const configWithEmptyIgnoredErrors = {
+  config: {
+    IGNORED_ERROR_REGEX: '',
+  },
+};
+const configWithWhitespaceIgnoredErrors = {
+  config: {
+    IGNORED_ERROR_REGEX: '     ',
+  },
+};
 const configWithMissingIgnoredErrors = {
   config: {},
 };
@@ -125,6 +135,20 @@ describe('NewRelicLoggingService', () => {
 
     it('calls New Relic client as error object but with null ignored error config', () => {
       service = new NewRelicLoggingService(configWithNullIgnoredErrors);
+      const error = new Error('Ignore this error!');
+      service.logError(error);
+      expect(global.newrelic.noticeError).toHaveBeenCalledWith(error, undefined);
+    });
+
+    it('calls New Relic client as error object but with empty ignored error config', () => {
+      service = new NewRelicLoggingService(configWithEmptyIgnoredErrors);
+      const error = new Error('Ignore this error!');
+      service.logError(error);
+      expect(global.newrelic.noticeError).toHaveBeenCalledWith(error, undefined);
+    });
+
+    it('calls New Relic client as error object but with whitespace-only ignored error config', () => {
+      service = new NewRelicLoggingService(configWithWhitespaceIgnoredErrors);
       const error = new Error('Ignore this error!');
       service.logError(error);
       expect(global.newrelic.noticeError).toHaveBeenCalledWith(error, undefined);


### PR DESCRIPTION
**Description:**

The IGNORED_ERROR_REGEX variable is an optional parameter, so the config and
logging code should work fine without the variable being defined. As MFEs upgrade
to the newest version of frontend-platform, the new version should *not* require
the addition of IGNORED_ERROR_REGEX to function properly. This commit fixes the
previous code, which inadvertently required this variable to be defined.

TNL-7924

**Merge checklist:**

- [ ] Consider running your code modifications in the included example app within `frontend-platform`. This can be done by running `npm start` and opening http://localhost:8080.
- [ ] Consider testing your code modifications in another local micro-frontend using local aliases configured via [the `module.config.js` file in `frontend-build`](https://github.com/edx/frontend-build#local-module-configuration-for-webpack).
- [ ] Verify your commit title/body conforms to the conventional commits format (e.g., `fix`, `feat`) and is appropriate for your code change. Consider whether your code is a breaking change, and modify your commit accordingly.

**Post merge:**

- [ ] After the build finishes for the merged commit, verify the new release has been pushed to [NPM](https://www.npmjs.com/package/@edx/frontend-platform).
