### PR TITLE
fix: Properly handle an error object sent into logInfo().

### DIFF
--- a/src/logging/NewRelicLoggingService.test.js
+++ b/src/logging/NewRelicLoggingService.test.js
@@ -46,12 +46,50 @@ describe('NewRelicLoggingService', () => {
       expect(global.newrelic.addPageAction).toHaveBeenCalledWith('INFO', { message });
     });
 
-    it('passes info parameters properly with custom attributes', () => {
+    it('handles plain string message properly with custom attributes', () => {
       const message = 'Test log';
-      const customAttrs = { a: 1, b: 'red', c: 3 };
-      service.logInfo(message, customAttrs);
+      const attrs = { a: 1, b: 'red', c: 3 };
+      service.logInfo(message, attrs);
       expect(global.newrelic.addPageAction).toHaveBeenCalledWith('INFO', {
-        message: 'Test log', a: 1, b: 'red', c: 3,
+        message, ...attrs,
+      });
+    });
+
+    it('handles plain string message properly with no custom attributes', () => {
+      const message = 'Test log';
+      service.logInfo(message);
+      expect(global.newrelic.addPageAction).toHaveBeenCalledWith('INFO', {
+        message,
+      });
+    });
+
+    it('handles error object properly with custom attributes', () => {
+      const message = 'Test log';
+      const attrs = { a: 1, b: 'red', c: 3 };
+      const err = { message, customAttributes: attrs };
+      service.logInfo(err);
+      expect(global.newrelic.addPageAction).toHaveBeenCalledWith('INFO', {
+        message, ...attrs,
+      });
+    });
+
+    it('handles error object properly with no custom attributes', () => {
+      const message = 'Test log';
+      const err = { message };
+      service.logInfo(err);
+      expect(global.newrelic.addPageAction).toHaveBeenCalledWith('INFO', {
+        message,
+      });
+    });
+
+    it('handles error object properly with custom attributes in object and param', () => {
+      const message = 'Test log';
+      const attrsObj = { a: 1, b: 'red', c: 3 };
+      const attrsParam = { x: 99, y: 'blue', z: 987 };
+      const err = { message, customAttributes: attrsObj };
+      service.logInfo(err, attrsParam);
+      expect(global.newrelic.addPageAction).toHaveBeenCalledWith('INFO', {
+        message, ...attrsObj, ...attrsParam,
       });
     });
   });


### PR DESCRIPTION
**Description:**

At several places in certain MFEs, logInfo() is called with a caught error
object. But logInfo() has always assumed that only a string will be passed-in.
This situation causes a JSON object to be send to New Relic as the "message"
of an info log, which makes the info logs difficult to search.

This change adds support for either an info string -or- and error object being
sent to logInfo(). The proper "message" is logged either way.

Example:

In this MFE location, the error object is logged via logInfo():

https://github.com/edx/frontend-app-authn/blob/8fe7f93ac09b6dbee95069eca8d5284241234cae/src/register/data/sagas.js#L36

yielding a page action with an incorrect message:

```
        {
          "actionName": "INFO",
          "appId": 799783938,
          "appName": "prod-frontend-app-authn",
          "asnLatitude": "26.120605",
          "asnLongitude": "91.65231",
          "browserHeight": 657,
          "browserWidth": 1349,
          "city": "Guwahati",
          "countryCode": "IN",
          "currentUrl": "https://authn.edx.org/register",
          "deviceType": "Desktop",
          "entityGuid": "ODgxNzh8QlJPV1NFUnxBUFBMSUNBVElPTnw3OTk3ODM5Mzg",
          "message": "{\"customAttributes\":{\"httpErrorType\":\"api-response-error\",\"httpErrorStatus\":409,\"httpErrorResponseData\":\"{\\\"email\\\":[{\\\"user_message\\\":\\\"It looks like xxxxxxxxx@gmail.com belongs to an existing account. Try again with a different email address.\\\"}],\\\"username\\\":[{\\\"user_message\\\":\\\"It looks like janu belongs to an existing account. Try again with a different username.\\\"}],\\\"username_suggestions\\\":[\\\"janu_5\\\",\\\"janu_36\\\",\\\"janu_481\\\"],\\\"error_code\\\":\\\"duplicate-email-username\\\"}\",\"httpErrorRequestUrl\":\"https://courses.edx.org/user_api/v2/account/registration/\",\"httpErrorRequestMethod\":\"post\"},\"message\":\"Axios Error (Response): 409 https://courses.edx.org/user_api/v2/account/registration/ {\\\"email\\\":[{\\\"user_message\\\":\\\"It looks like xxxxxxxxxx@gmail.com belongs to an existing account. Try again with a different email address.\\\"}],\\\"username\\\":[{\\\"user_message\\\":\\\"It looks like janu belongs to an existing account. Try again with a different username.\\\"}],\\\"username_suggestions\\\":[\\\"janu_5\\\",\\\"janu_36\\\",\\\"janu_481\\\"],\\\"error_code\\\":\\\"duplicate-email-username\\\"}\"}",
          "name": "Unnamed Transaction",
          "pageUrl": "https://authn.edx.org/register",
          "referrerUrl": "https://www.edx.org/",
          "regionCode": "03",
          "session": "a7fa4da4c1bb9e73",
          "timeSinceLoad": 134.521,
          "timestamp": 1621352070953,
          "userAgentName": "Microsoft Edge",
          "userAgentOS": "Windows",
          "userAgentVersion": "90"
        },
```
This change will instead yield a page action which looks like this:
```
        {
          "actionName": "INFO",
          "appId": 799783938,
          "appName": "prod-frontend-app-authn",
          "asnLatitude": "26.120605",
          "asnLongitude": "91.65231",
          "browserHeight": 657,
          "browserWidth": 1349,
          "city": "Guwahati",
          "countryCode": "IN",
          "currentUrl": "https://authn.edx.org/register",
          "deviceType": "Desktop",
          "entityGuid": "ODgxNzh8QlJPV1NFUnxBUFBMSUNBVElPTnw3OTk3ODM5Mzg",
          "httpErrorRequestMethod": "post",
          "httpErrorRequestUrl": https://courses.edx.org/user_api/v2/account/registration/",
          "httpErrorResponseData": \"{\"email\":[{\"user_message\":\"It looks like xxxxxxxxx@gmail.com belongs to an existing account. Try again with a different email address.\"}],\"username\":[{\"user_message\":\"It looks like janu belongs to an existing account. Try again with a different username.\"}],\"username_suggestions\":[\"janu_5\",\"janu_36\",\"janu_481\"],\"error_code\":\"duplicate-email-username\"}\"}",
          "httpErrorStatus": 409,
          "httpErrorType": "api-response-error",
          "message": "Axios Error (Response): 409 https://courses.edx.org/user_api/v2/account/registration/ ",
          "name": "Unnamed Transaction",
          "pageUrl": "https://authn.edx.org/register",
          "referrerUrl": "https://www.edx.org/",
          "regionCode": "03",
          "session": "a7fa4da4c1bb9e73",
          "timeSinceLoad": 134.521,
          "timestamp": 1621352070953,
          "userAgentName": "Microsoft Edge",
          "userAgentOS": "Windows",
          "userAgentVersion": "90"
        },
```

https://openedx.atlassian.net/browse/TNL-8336

**Merge checklist:**

- [ ] Consider running your code modifications in the included example app within `frontend-platform`. This can be done by running `npm start` and opening http://localhost:8080.
- [ ] Consider testing your code modifications in another local micro-frontend using local aliases configured via [the `module.config.js` file in `frontend-build`](https://github.com/edx/frontend-build#local-module-configuration-for-webpack).
- [ ] Verify your commit title/body conforms to the conventional commits format (e.g., `fix`, `feat`) and is appropriate for your code change. Consider whether your code is a breaking change, and modify your commit accordingly.

**Post merge:**

- [ ] After the build finishes for the merged commit, verify the new release has been pushed to [NPM](https://www.npmjs.com/package/@edx/frontend-platform).
