### PR TITLE
Make config value passable by users

### DIFF
--- a/src/initialize.js
+++ b/src/initialize.js
@@ -213,6 +213,7 @@ export async function initialize({
   hydrateAuthenticatedUser: hydrateUser = false,
   messages,
   handlers: overrideHandlers = {},
+  config = getConfig()
 }) {
   const handlers = applyOverrideHandlers(overrideHandlers);
   try {
@@ -226,7 +227,7 @@ export async function initialize({
 
     // Logging
     configureLogging(loggingService, {
-      config: getConfig(),
+      config: config,
     });
     await handlers.logging();
     publish(APP_LOGGING_INITIALIZED);
@@ -234,14 +235,14 @@ export async function initialize({
     // Authentication
     configureAuth(authService, {
       loggingService: getLoggingService(),
-      config: getConfig(),
+      config: config,
     });
     await handlers.auth(requireUser, hydrateUser);
     publish(APP_AUTH_INITIALIZED);
 
     // Analytics
     configureAnalytics(analyticsService, {
-      config: getConfig(),
+      config: config,
       loggingService: getLoggingService(),
       httpClient: getAuthenticatedHttpClient(),
     });
@@ -251,7 +252,7 @@ export async function initialize({
     // Internationalization
     configureI18n({
       messages,
-      config: getConfig(),
+      config: config,
       loggingService: getLoggingService(),
     });
     await handlers.i18n();


### PR DESCRIPTION
This would allow `frontend-platform` to be used while creating other
custom MFEs on top of platforms like gatsbyjs, nextjs, create-react-app
and/or others because the environment variables in these frameworks have
to be prepended by a pre-defined name, like `REACT_APP` for
`create-react-app` making `frontend-platform` library to automatically
get the env variables like it does now from './config' since the names
don't and can't be matched to meet expectaions of all libraries.

**Description:**

Describe what this pull request changes, and why. Include implications for people using this change.

**Merge checklist:**

- [ ] Consider running your code modifications in the included example app within `frontend-platform`. This can be done by running `npm start` and opening http://localhost:8080.
- [ ] Consider testing your code modifications in another local micro-frontend using local aliases configured via [the `module.config.js` file in `frontend-build`](https://github.com/edx/frontend-build#local-module-configuration-for-webpack).
- [ ] Verify your commit title/body conforms to the conventional commits format (e.g., `fix`, `feat`) and is appropriate for your code change. Consider whether your code is a breaking change, and modify your commit accordingly.

**Post merge:**

- [ ] After the build finishes for the merged commit, verify the new release has been pushed to [NPM](https://www.npmjs.com/package/@edx/frontend-platform).
