### PR TITLE
feat(auth): allow forceRefresh in fetchAuthenticatedUser

### DIFF
--- a/src/auth/AxiosJwtAuthService.js
+++ b/src/auth/AxiosJwtAuthService.js
@@ -208,6 +208,8 @@ class AxiosJwtAuthService {
         roles: decodedAccessToken.roles || [],
         administrator: decodedAccessToken.administrator,
       });
+    } else {
+      this.setAuthenticatedUser(null);
     }
 
     return this.getAuthenticatedUser();

--- a/src/auth/AxiosJwtAuthService.js
+++ b/src/auth/AxiosJwtAuthService.js
@@ -197,8 +197,8 @@ class AxiosJwtAuthService {
    * @returns {Promise<UserData>|Promise<null>} Resolves to the user's access token if they are
    * logged in.
    */
-  async fetchAuthenticatedUser() {
-    const decodedAccessToken = await this.jwtTokenService.getJwtToken();
+  async fetchAuthenticatedUser(options = {}) {
+    const decodedAccessToken = await this.jwtTokenService.getJwtToken(options.forceRefresh || false);
 
     if (decodedAccessToken !== null) {
       this.setAuthenticatedUser({

--- a/src/auth/AxiosJwtAuthService.test.jsx
+++ b/src/auth/AxiosJwtAuthService.test.jsx
@@ -772,6 +772,34 @@ describe('ensureAuthenticatedUser', () => {
   });
 });
 
+describe('fetchAuthenticatedUser', () => {
+  it('refreshes a missing jwt token and returns a user access token', () => {
+    setJwtCookieTo(null);
+    setJwtTokenRefreshResponseTo(200, jwtTokens.valid.encoded);
+    return service.fetchAuthenticatedUser().then((authenticatedUserAccessToken) => {
+      expect(authenticatedUserAccessToken).toEqual(jwtTokens.valid.formatted);
+      expectSingleCallToJwtTokenRefresh();
+    });
+  });
+
+  it('found a valid token from cache and no call for refresh', () => {
+    setJwtCookieTo(jwtTokens.valid.encoded);
+    return service.fetchAuthenticatedUser().then((authenticatedUserAccessToken) => {
+      expect(authenticatedUserAccessToken).toEqual(jwtTokens.valid.formatted);
+      expectNoCallToJwtTokenRefresh();
+    });
+  });
+
+  it('refreshes the token forcefully even if token is not yet expired', () => {
+    setJwtCookieTo(jwtTokens.valid.encoded);
+    setJwtTokenRefreshResponseTo(200, jwtTokens.valid.encoded);
+    return service.fetchAuthenticatedUser({ forceRefresh: true }).then((authenticatedUserAccessToken) => {
+      expect(authenticatedUserAccessToken).toEqual(jwtTokens.valid.formatted);
+      expectSingleCallToJwtTokenRefresh();
+    });
+  });
+});
+
 // These tests all make real network calls to https://httpbin.org, just as documented in the axios-cache-adapter
 // tests. axios-mock-adapter can not be used to mock requests with axios-cache-adapter.
 describe('Cache Functionality', () => {

--- a/src/auth/AxiosJwtAuthService.test.jsx
+++ b/src/auth/AxiosJwtAuthService.test.jsx
@@ -792,9 +792,9 @@ describe('fetchAuthenticatedUser', () => {
 
   it('refreshes the token forcefully even if token is not yet expired', () => {
     setJwtCookieTo(jwtTokens.valid.encoded);
-    setJwtTokenRefreshResponseTo(200, jwtTokens.valid.encoded);
+    setJwtTokenRefreshResponseTo(401, null);
     return service.fetchAuthenticatedUser({ forceRefresh: true }).then((authenticatedUserAccessToken) => {
-      expect(authenticatedUserAccessToken).toEqual(jwtTokens.valid.formatted);
+      expect(authenticatedUserAccessToken).toEqual(null);
       expectSingleCallToJwtTokenRefresh();
     });
   });

--- a/src/auth/AxiosJwtTokenService.js
+++ b/src/auth/AxiosJwtTokenService.js
@@ -100,10 +100,10 @@ export default class AxiosJwtTokenService {
     return this.refreshRequestPromises[this.tokenCookieName];
   }
 
-  async getJwtToken() {
+  async getJwtToken(forceRefresh = false) {
     try {
       const decodedJwtToken = this.decodeJwtCookie(this.tokenCookieName);
-      if (!AxiosJwtTokenService.isTokenExpired(decodedJwtToken)) {
+      if (!AxiosJwtTokenService.isTokenExpired(decodedJwtToken) && !forceRefresh) {
         return decodedJwtToken;
       }
     } catch (e) {

--- a/src/auth/interface.js
+++ b/src/auth/interface.js
@@ -217,8 +217,8 @@ export function setAuthenticatedUser(authUser) {
  * @returns {Promise<UserData>|Promise<null>} Resolves to the user's access token if they are
  * logged in.
  */
-export async function fetchAuthenticatedUser() {
-  return service.fetchAuthenticatedUser();
+export async function fetchAuthenticatedUser(options = {}) {
+  return service.fetchAuthenticatedUser(options);
 }
 
 /**


### PR DESCRIPTION
**Description:**
Allow an optional parameter in `fetchAuthenticatedUser` that forces it to refresh the JWT token even if the token is not yet expired.

VAN-682

**Merge checklist:**

- [x] Consider running your code modifications in the included example app within `frontend-platform`. This can be done by running `npm start` and opening http://localhost:8080.
- [x] Consider testing your code modifications in another local micro-frontend using local aliases configured via [the `module.config.js` file in `frontend-build`](https://github.com/edx/frontend-build#local-module-configuration-for-webpack).
- [x] Verify your commit title/body conforms to the conventional commits format (e.g., `fix`, `feat`) and is appropriate for your code change. Consider whether your code is a breaking change, and modify your commit accordingly.

**Post merge:**

- [ ] After the build finishes for the merged commit, verify the new release has been pushed to [NPM](https://www.npmjs.com/package/@edx/frontend-platform).
