### PR TITLE
fix: add browser time to log message

### DIFF
--- a/src/auth/AxiosJwtAuthService.test.jsx
+++ b/src/auth/AxiosJwtAuthService.test.jsx
@@ -167,14 +167,12 @@ expect.extend({
     const pass = received >= floor && received <= ceiling;
     if (pass) {
       return {
-        message: () =>
-          `expected ${received} not to be within range ${floor} - ${ceiling}`,
+        message: () => `expected ${received} not to be within range ${floor} - ${ceiling}`,
         pass: true,
       };
     }
     return {
-      message: () =>
-        `expected ${received} to be within range ${floor} - ${ceiling}`,
+      message: () => `expected ${received} to be within range ${floor} - ${ceiling}`,
       pass: false,
     };
   },

--- a/src/auth/AxiosJwtTokenService.js
+++ b/src/auth/AxiosJwtTokenService.js
@@ -61,7 +61,7 @@ export default class AxiosJwtTokenService {
           try {
             axiosResponse = await this.httpClient.post(this.tokenRefreshEndpoint);
             // eslint-disable-next-line max-len
-            if (axiosResponse.data && axiosResponse.data.response_epoch_seconds && axiosResponse.data.expires_epoch_seconds) {
+            if (axiosResponse.data && axiosResponse.data.response_epoch_seconds) {
               responseServerEpochSeconds = axiosResponse.data.response_epoch_seconds;
             }
           } catch (error) {


### PR DESCRIPTION
**Description:**

To help debug an odd issue where the cookie is not
appearing after a successful refresh, adding additional
data to test hypothesis that the browser time may have
drifted enough that the cookie is expired by the time it
arrives.

**Merge checklist:**

- [x] Consider running your code modifications in the included example app within `frontend-platform`. This can be done by running `npm start` and opening http://localhost:8080.
- [x] Consider testing your code modifications in another local micro-frontend using local aliases configured via [the `module.config.js` file in `frontend-build`](https://github.com/edx/frontend-build#local-module-configuration-for-webpack).
- [x] Verify your commit title/body conforms to the conventional commits format (e.g., `fix`, `feat`) and is appropriate for your code change. Consider whether your code is a breaking change, and modify your commit accordingly.

**Post merge:**

- [ ] After the build finishes for the merged commit, verify the new release has been pushed to [NPM](https://www.npmjs.com/package/@edx/frontend-platform).
