### PR TITLE
fix: identifyAnonymousUser promise not resolving

### DIFF
--- a/src/analytics/SegmentAnalyticsService.js
+++ b/src/analytics/SegmentAnalyticsService.js
@@ -170,7 +170,7 @@ class SegmentAnalyticsService {
    * @returns {Promise} Promise that will resolve once the document readyState is complete
    */
   identifyAnonymousUser(traits) {
-    if (!this.segmentInitialized || global.analytics.user === undefined) {
+    if (!this.segmentInitialized) {
       return Promise.resolve();
     }
     // if we do not have an authenticated user (indicated by being in this method),
@@ -186,6 +186,10 @@ class SegmentAnalyticsService {
         this.hasIdentifyBeenCalled = true;
         resolve();
       });
+
+      // if the segment domain is blocked on user's network/browser, this promis does not get
+      // resolved and user see a blank page, set timeout out to resolve the promise.
+      setTimeout(resolve, 2000);
     });
   }
 


### PR DESCRIPTION
**Description:**

This is an update to a previous fix: https://github.com/edx/frontend-platform/pull/208

If the Segment key is invalid or the user has blocked the segment domain using a plugin or extension; the promise does not get resolved and app initialization fails resulting into a blank page.

Set timeout to resolve the promise in case the Segment script is not loaded successfully.

VAN-689

**Merge checklist:**

- [x] Consider running your code modifications in the included example app within `frontend-platform`. This can be done by running `npm start` and opening http://localhost:8080.
- [x] Consider testing your code modifications in another local micro-frontend using local aliases configured via [the `module.config.js` file in `frontend-build`](https://github.com/edx/frontend-build#local-module-configuration-for-webpack).
- [x] Verify your commit title/body conforms to the conventional commits format (e.g., `fix`, `feat`) and is appropriate for your code change. Consider whether your code is a breaking change, and modify your commit accordingly.

**Post merge:**

- [ ] After the build finishes for the merged commit, verify the new release has been pushed to [NPM](https://www.npmjs.com/package/@edx/frontend-platform).
