### PR TITLE
fix(analytics): avoid errors when we bail on segment identification

### DIFF
--- a/src/analytics/SegmentAnalyticsService.js
+++ b/src/analytics/SegmentAnalyticsService.js
@@ -187,9 +187,13 @@ class SegmentAnalyticsService {
         resolve();
       });
 
-      // if the segment domain is blocked on user's network/browser, this promis does not get
+      // if the segment domain is blocked on user's network/browser, this promise does not get
       // resolved and user see a blank page, set timeout out to resolve the promise.
-      setTimeout(resolve, 2000);
+      setTimeout(() => {
+        // Other segment calls won't work if we are not identified. So let's just un-initialize ourselves.
+        this.segmentInitialized = false;
+        resolve();
+      }, 2000);
     });
   }
 


### PR DESCRIPTION
If we timeout during segment identification, stop any further segment calls from happening, as they will fail anyway. And that just generates JS error churn.

This was noticed because about 18% of the learning MFE JS errors are now "Identify must be called before other tracking events." after we recently updated to the latest `frontend-platform`. I'm not sure this code path I fixed is 100% responsible for that uptick. But it certainly *can* result in that error.