### PR TITLE
fix: blank page issue if google analytics blocked

### DIFF
--- a/src/analytics/SegmentAnalyticsService.js
+++ b/src/analytics/SegmentAnalyticsService.js
@@ -192,10 +192,18 @@ class SegmentAnalyticsService {
         resolve();
       });
 
-      // this is added to handle a specific use-case where if a user has blocked the segment
-      // domain in their browser, this promise does not get resolved and user see a blank
+      // this is added to handle a specific use-case where if a user has blocked the analytics
+      // tools in their browser, this promise does not get resolved and user sees a blank
       // page. Dispatching this event in script.onerror callback in analytics.load.
       document.addEventListener('segmentFailed', resolve);
+      // This is added to handle the google analytics blocked case which is injected into
+      // the DOM by segment.min.js.
+      setTimeout(() => {
+        if (!global.ga || !global.ga.create) {
+          this.segmentInitialized = false;
+          resolve();
+        }
+      }, 2000);
     });
   }
 


### PR DESCRIPTION
**Description:**

The promise in `identifyAnonymousUser` has been causing issues with app initialization if a user blocks the analytics tools (e.g. segment.com, google-analytics.com) in their browser. Removing this promise, since we cannot handle the failures for google-analytics.com snippet which is loaded by the segment.min.js.

**Steps To Reproduce**

1. Visit https://authn.edx.org/register
2. Open browser inspector tools 
3. Go to the network tab and block www.google-analytics.com
4. Reload the page and you will see a blank page instead of registration form
<img width="1680" alt="Screenshot 2021-10-21 at 3 54 20 PM" src="https://user-images.githubusercontent.com/2851134/138264016-d224dd72-d06e-43f6-8916-d88eee59e987.png">

**Merge checklist:**

- [x] Consider running your code modifications in the included example app within `frontend-platform`. This can be done by running `npm start` and opening http://localhost:8080.
- [x] Consider testing your code modifications in another local micro-frontend using local aliases configured via [the `module.config.js` file in `frontend-build`](https://github.com/edx/frontend-build#local-module-configuration-for-webpack).
- [x] Verify your commit title/body conforms to the conventional commits format (e.g., `fix`, `feat`) and is appropriate for your code change. Consider whether your code is a breaking change, and modify your commit accordingly.

**Post merge:**

- [ ] After the build finishes for the merged commit, verify the new release has been pushed to [NPM](https://www.npmjs.com/package/@edx/frontend-platform).
