### PR TITLE
build: pin semantic-release to v17 in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ script:
 - npm run build
 - npm run docs
 after_success:
-- npx semantic-release
+- npx semantic-release@17
 - codecov
 deploy:
   provider: pages


### PR DESCRIPTION
**Description:**

The semantic-release package dropped support for node 12 in its v18.0.0 release.  This breaks our builds since we're on node 12.  This commit pins our version of semantic-release to 17 so we can keep working until we finally update node.

**Merge checklist:**

- [ ] Consider running your code modifications in the included example app within `frontend-platform`. This can be done by running `npm start` and opening http://localhost:8080.
- [ ] Consider testing your code modifications in another local micro-frontend using local aliases configured via [the `module.config.js` file in `frontend-build`](https://github.com/edx/frontend-build#local-module-configuration-for-webpack).
- [ ] Verify your commit title/body conforms to the conventional commits format (e.g., `fix`, `feat`) and is appropriate for your code change. Consider whether your code is a breaking change, and modify your commit accordingly.

**Post merge:**

- [ ] After the build finishes for the merged commit, verify the new release has been pushed to [NPM](https://www.npmjs.com/package/@edx/frontend-platform).
