### PR TITLE
fix: blank page issue if GTM domain is blocked

### DIFF
--- a/src/analytics/SegmentAnalyticsService.js
+++ b/src/analytics/SegmentAnalyticsService.js
@@ -199,7 +199,7 @@ class SegmentAnalyticsService {
       // This is added to handle the google analytics blocked case which is injected into
       // the DOM by segment.min.js.
       setTimeout(() => {
-        if (!global.ga || !global.ga.create) {
+        if (!global.ga || !global.ga.create || !global.google_tag_manager) {
           this.segmentInitialized = false;
           resolve();
         }


### PR DESCRIPTION
**Steps To Reproduce:**

1. Visit https://authn.edx.org/register
2. Open browser inspector tools
3. Go to the Network tab and block [www.googletagmanager.com](http://www.googletagmanager.com)
4. Reload the page and you will see a blank page instead of the register page

**Merge checklist:**

- [x] Consider running your code modifications in the included example app within `frontend-platform`. This can be done by running `npm start` and opening http://localhost:8080.
- [x] Consider testing your code modifications in another local micro-frontend using local aliases configured via [the `module.config.js` file in `frontend-build`](https://github.com/edx/frontend-build#local-module-configuration-for-webpack).
- [x] Verify your commit title/body conforms to the conventional commits format (e.g., `fix`, `feat`) and is appropriate for your code change. Consider whether your code is a breaking change, and modify your commit accordingly.

**Post merge:**

- [ ] After the build finishes for the merged commit, verify the new release has been pushed to [NPM](https://www.npmjs.com/package/@edx/frontend-platform).
