### PR TITLE
maint: update paragon range to resolve peer deps with new npm version

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "universal-cookie": "4.0.4"
   },
   "peerDependencies": {
-    "@edx/paragon": ">= 10.0.0 <= ^16.0.0",
+    "@edx/paragon": ">= 10.0.0 < 17.0.0",
     "prop-types": "^15.7.2",
     "react": "^16.9.0",
     "react-dom": "^16.9.0",


### PR DESCRIPTION
**Description:**

Update paragon to <=^17.0.0 so we can test new npm version with paragon v16.y.z

When I build an MFE with npm 8 + node16, somehow the new npm resolution fails as following, due to paragon not being in the range

```
~/work/frontend-app-learner-portal-enterprise (master ✘)✖✹✭ ᐅ npm i                                     
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR! 
npm ERR! While resolving: frontend-app-learner-portal-enterprise@0.1.0
npm ERR! Found: @edx/paragon@16.14.7
npm ERR! node_modules/@edx/paragon
npm ERR!   @edx/paragon@"16.14.7" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer @edx/paragon@">=10.0.0 <15.0.0" from @edx/frontend-platform@1.11.0
npm ERR! node_modules/@edx/frontend-platform
npm ERR!   @edx/frontend-platform@"1.11.0" from the root project
npm ERR!   peer @edx/frontend-platform@"^1.8.0" from @edx/frontend-component-footer@10.1.0
npm ERR!   node_modules/@edx/frontend-component-footer
npm ERR!     @edx/frontend-component-footer@"10.1.0" from the root project
```

**Merge checklist:**

- [ ] Consider running your code modifications in the included example app within `frontend-platform`. This can be done by running `npm start` and opening http://localhost:8080.
- [ ] Consider testing your code modifications in another local micro-frontend using local aliases configured via [the `module.config.js` file in `frontend-build`](https://github.com/edx/frontend-build#local-module-configuration-for-webpack).
- [x] Verify your commit title/body conforms to the conventional commits format (e.g., `fix`, `feat`) and is appropriate for your code change. Consider whether your code is a breaking change, and modify your commit accordingly.

**Post merge:**

- [ ] After the build finishes for the merged commit, verify the new release has been pushed to [NPM](https://www.npmjs.com/package/@edx/frontend-platform).
