### PR TITLE
feat: make externalScripts configurable via env.config.js

### DIFF
--- a/src/initialize.js
+++ b/src/initialize.js
@@ -270,7 +270,7 @@ function applyOverrideHandlers(overrides) {
  * implementation to use.
  * @param {*} [options.authMiddleware=[]] An array of middleware to apply to http clients in the auth service.
  * @param {*} [options.externalScripts=[GoogleAnalyticsLoader]] An array of externalScripts.
- * By default added GoogleAnalyticsLoader.
+ * Can also be configured via `externalScripts` in env.config.js.
  * @param {*} [options.requireAuthenticatedUser=false] If true, turns on automatic login
  * redirection for unauthenticated users.  Defaults to false, meaning that by default the
  * application will allow anonymous/unauthenticated sessions.
@@ -308,10 +308,6 @@ export async function initialize({
     await runtimeConfig();
     publish(APP_CONFIG_INITIALIZED);
 
-    loadExternalScripts(externalScripts, {
-      config: getConfig(),
-    });
-
     // This allows us to replace the implementations of the logging, analytics, and auth services
     // based on keys in the ConfigDocument.  The JavaScript File Configuration method is the only
     // one capable of supplying an alternative implementation since it can import other modules.
@@ -320,6 +316,11 @@ export async function initialize({
     const loggingServiceImpl = getConfig().loggingService || loggingService;
     const analyticsServiceImpl = getConfig().analyticsService || analyticsService;
     const authServiceImpl = getConfig().authService || authService;
+    const externalScriptsImpl = getConfig().externalScripts || externalScripts;
+
+    loadExternalScripts(externalScriptsImpl, {
+      config: getConfig(),
+    });
 
     // Logging
     configureLogging(loggingServiceImpl, {

--- a/src/initialize.test.js
+++ b/src/initialize.test.js
@@ -10,7 +10,7 @@ import {
   APP_READY,
   APP_INIT_ERROR,
 } from './constants';
-import { initialize } from './initialize';
+import { initialize, loadExternalScripts } from './initialize';
 import { subscribe } from './pubSub';
 
 import {
@@ -351,6 +351,63 @@ describe('initialize', () => {
     expect(ensureAuthenticatedUser).not.toHaveBeenCalled();
     expect(hydrateAuthenticatedUser).not.toHaveBeenCalled();
     expect(logError).not.toHaveBeenCalled();
+  });
+
+  it('should load externalScripts from config when provided', async () => {
+    const mockScript = jest.fn().mockImplementation(() => ({ loadScript: jest.fn() }));
+    config.externalScripts = [mockScript];
+
+    await initialize({ messages: null });
+
+    expect(mockScript).toHaveBeenCalledWith({ config });
+    delete config.externalScripts;
+  });
+
+  it('should fall back to externalScripts parameter when config has none', async () => {
+    const mockScript = jest.fn().mockImplementation(() => ({ loadScript: jest.fn() }));
+
+    await initialize({ messages: null, externalScripts: [mockScript] });
+
+    expect(mockScript).toHaveBeenCalledWith({ config });
+  });
+
+  it('should load GoogleAnalyticsLoader by default', async () => {
+    const { GoogleAnalyticsLoader: GALoader } = jest.requireActual('./scripts');
+    const loadScriptSpy = jest.spyOn(GALoader.prototype, 'loadScript').mockImplementation(() => {});
+
+    await initialize({ messages: null });
+
+    expect(loadScriptSpy).toHaveBeenCalled();
+    loadScriptSpy.mockRestore();
+  });
+
+  it('should prefer config externalScripts over the parameter', async () => {
+    const configScript = jest.fn().mockImplementation(() => ({ loadScript: jest.fn() }));
+    const paramScript = jest.fn().mockImplementation(() => ({ loadScript: jest.fn() }));
+    config.externalScripts = [configScript];
+
+    await initialize({ messages: null, externalScripts: [paramScript] });
+
+    expect(configScript).toHaveBeenCalled();
+    expect(paramScript).not.toHaveBeenCalled();
+    delete config.externalScripts;
+  });
+});
+
+describe('loadExternalScripts', () => {
+  it('should instantiate each script with data and call loadScript', () => {
+    const loadScript = jest.fn();
+    const MockScript = jest.fn().mockImplementation(() => ({ loadScript }));
+    const data = { config: { some: 'value' } };
+
+    loadExternalScripts([MockScript], data);
+
+    expect(MockScript).toHaveBeenCalledWith(data);
+    expect(loadScript).toHaveBeenCalled();
+  });
+
+  it('should handle an empty array', () => {
+    expect(() => loadExternalScripts([], {})).not.toThrow();
   });
 });
 


### PR DESCRIPTION
### Description

Currently, `externalScripts` in `initialize()` cannot be configured via `env.config.js`, unlike other services such as `loggingService`, `analyticsService`, and `authService`.

This change makes `externalScripts` resolvable from the config object, following the same `getConfig().externalScripts || externalScripts` pattern already used for the other services. The `loadExternalScripts` call is moved after config resolution so the config-based value is available. `GoogleAnalyticsLoader` remains the default.

Operators who want to customize the list can do so in their `env.config.js`:

```js
import { GoogleAnalyticsLoader } from '@edx/frontend-platform/scripts';
import { CustomScript } from './scripts';

const config = {
  externalScripts: [GoogleAnalyticsLoader, CustomScript],
};

export default config;
```

Closes #877.

### LLM usage notice

Built with assistance from Claude.