### PR TITLE
feat: support appending externalScripts via env.config

### DIFF
--- a/src/initialize.js
+++ b/src/initialize.js
@@ -308,7 +308,10 @@ export async function initialize({
     await runtimeConfig();
     publish(APP_CONFIG_INITIALIZED);
 
-    loadExternalScripts(externalScripts, {
+    // Merge default scripts with any additional injected ones passed via env.config
+    const injectedScripts = getConfig().injectedScripts || [];
+    const externalScriptsImpl = [...injectedScripts, ...externalScripts];
+    loadExternalScripts(externalScriptsImpl, {
       config: getConfig(),
     });
 


### PR DESCRIPTION
Allows MFEs to inject arbitrary scripts (like analytics or cookie consent) at runtime. Merges `getConfig().injectedScripts` with the default `externalScripts` array before passing them to the script loader. 

Cooperates with an _INJECTED_SCRIPTS_ hook written analogically to _PLUGIN_SLOTS_ and requested under PR https://github.com/overhangio/tutor-mfe/pull/289 