### PR TITLE
feat: map profile image URL to authenticatedUser.avatar on hydration

### DIFF
--- a/src/auth/AxiosJwtAuthService.js
+++ b/src/auth/AxiosJwtAuthService.js
@@ -296,7 +296,12 @@ class AxiosJwtAuthService {
     if (user !== null) {
       const response = await this.authenticatedHttpClient
         .get(`${this.config.LMS_BASE_URL}/api/user/v1/accounts/${user.username}`);
-      this.setAuthenticatedUser({ ...user, ...camelCaseObject(response.data) });
+      const userData = camelCaseObject(response.data);
+      this.setAuthenticatedUser({
+        ...user,
+        ...userData,
+        avatar: userData.profileImage?.imageUrlFull || null,
+      });
     }
   }
 


### PR DESCRIPTION
## Summary

When `hydrateAuthenticatedUser()` calls the accounts API, the response includes `profile_image.image_url_full` — either the user's uploaded photo or a backend-generated initials avatar. This URL was never mapped to `authenticatedUser.avatar`, so every MFE header was ignoring it and falling back to a generic icon.

This PR fixes that with a single change in `AxiosJwtAuthService.hydrateAuthenticatedUser()`:

```js
avatar: userData.profileImage?.imageUrlFull || null,
```

`authenticatedUser.avatar` is now populated for any MFE that calls `initialize()` with `hydrateAuthenticatedUser: true`, without requiring changes in individual MFEs.

## Context

This is part of a broader effort to replace the generic grey silhouette placeholder with a personalized initials avatar (a colored circle with the user's initials, similar to Google and Slack). The backend change that generates the initials image is in a companion PR:

- **Backend (openedx-platform):** openedx/openedx-platform#38638 — generates a JPEG initials avatar on the server when the user has no uploaded photo. The image URL is returned in `profile_image.image_url_full` from the accounts API.
- **Profile MFE:** openedx/frontend-app-profile#1351 — fixes the profile page body, which was checking `has_image` and ignoring any available URL.

This `frontend-platform` change is the piece that connects the backend output to every MFE header at once.

## How it works end to end

```
1. User logs in — backend generates initials avatar JPEG (if no uploaded photo)
2. MFE initializes with hydrateAuthenticatedUser: true
3. frontend-platform calls /api/user/v1/accounts/:username
4. profile_image.image_url_full → authenticatedUser.avatar  ← this PR
5. MFE header reads authenticatedUser.avatar and shows the image
```

Without this change, step 4 never happens and the header shows the generic icon regardless of what the backend returns.

## Changes

- `src/auth/AxiosJwtAuthService.js` — 6 lines added, 1 changed. No new dependencies, no API changes, no breaking changes.

## Test plan

- [ ] Start a local Open edX instance with the companion backend PR applied
- [ ] Log in as a user with no uploaded photo
- [ ] Open any MFE that calls `hydrateAuthenticatedUser: true` (profile, account, learner-dashboard)
- [ ] Confirm the header shows the initials avatar instead of a generic icon
- [ ] Upload a profile photo — confirm the header updates to the real photo
- [ ] Delete the photo — confirm the header returns to the initials avatar

🤖 Generated with [Claude Code](https://claude.com/claude-code)