### PR TITLE
chore: upgrade codecov-action to v7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         run: npm run docs
 
       - name: Run Coverage
-        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
+        uses: codecov/codecov-action@v7
         with:
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Test
       run: npm run test
     - name: Coverage
-      uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
+      uses: codecov/codecov-action@v7
       with:
         fail_ci_if_error: false
         token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
**Description:**
Upgrade `codecov/codecov-action` from `v5.5.4` to `v7` in `.github/workflows/manual-publish.yml` as specified in the ticket.

**Jira:**
[ENT-11952
](https://2u-internal.atlassian.net/browse/ENT-11952)
**Changes**
- update `.github/workflows/manual-publish.yml`
- change `codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe` to `codecov/codecov-action@v7`