### PR TITLE
feat: add Uzbek language support

### DIFF
--- a/src/i18n/countries.js
+++ b/src/i18n/countries.js
@@ -15,6 +15,7 @@ import ptLocale from 'i18n-iso-countries/langs/pt.json';
 import ruLocale from 'i18n-iso-countries/langs/ru.json';
 import ukLocale from 'i18n-iso-countries/langs/uk.json';
 import viLocale from 'i18n-iso-countries/langs/vi.json';
+import uzLocale from 'i18n-iso-countries/langs/uz.json';
 
 import { getPrimaryLanguageSubtag } from './lib';
 
@@ -41,6 +42,7 @@ COUNTRIES.registerLocale(ruLocale);
 // COUNTRIES.registerLocale(thLocale); // Doesn't exist in lib.
 COUNTRIES.registerLocale(ukLocale);
 COUNTRIES.registerLocale(viLocale);
+COUNTRIES.registerLocale(uzLocale);
 
 /**
  * Provides a lookup table of country IDs to country names for the current locale.

--- a/src/i18n/lib.js
+++ b/src/i18n/lib.js
@@ -18,6 +18,7 @@ import '@formatjs/intl-pluralrules/locale-data/ru';
 import '@formatjs/intl-pluralrules/locale-data/th';
 import '@formatjs/intl-pluralrules/locale-data/uk';
 import '@formatjs/intl-pluralrules/locale-data/vi';
+import '@formatjs/intl-pluralrules/locale-data/uz';
 
 import '@formatjs/intl-relativetimeformat/polyfill';
 import '@formatjs/intl-relativetimeformat/locale-data/ar';
@@ -35,6 +36,7 @@ import '@formatjs/intl-relativetimeformat/locale-data/ru';
 import '@formatjs/intl-relativetimeformat/locale-data/th';
 import '@formatjs/intl-relativetimeformat/locale-data/uk';
 import '@formatjs/intl-relativetimeformat/locale-data/vi';
+import '@formatjs/intl-relativetimeformat/locale-data/uz';
 
 const cookies = new Cookies();
 const supportedLocales = [
@@ -55,6 +57,7 @@ const supportedLocales = [
   'th', // Thai
   'uk', // Ukrainian
   'vi', // Vietnamese
+  'uz', // Uzbek
 ];
 const rtlLocales = [
   'ar', // Arabic
@@ -224,6 +227,7 @@ const messagesShape = {
   th: PropTypes.objectOf(PropTypes.string), // Thai
   uk: PropTypes.objectOf(PropTypes.string), // Ukrainian
   vi: PropTypes.objectOf(PropTypes.string), // Vietnamese
+  uz: PropTypes.objectOf(PropTypes.string), // Uzbek
 };
 
 const optionsShape = {

--- a/src/i18n/lib.test.js
+++ b/src/i18n/lib.test.js
@@ -80,7 +80,7 @@ describe('lib', () => {
         messages: {},
       });
 
-      expect(console.warn).toHaveBeenCalledTimes(16);
+      expect(console.warn).toHaveBeenCalledTimes(17);
       expect(console.warn).toHaveBeenCalledWith('Missing locale: ar');
       expect(console.warn).toHaveBeenCalledWith('Missing locale: es-419');
       expect(console.warn).toHaveBeenCalledWith('Missing locale: fr');
@@ -95,6 +95,7 @@ describe('lib', () => {
       expect(console.warn).toHaveBeenCalledWith('Missing locale: th');
       expect(console.warn).toHaveBeenCalledWith('Missing locale: uk');
       expect(console.warn).toHaveBeenCalledWith('Missing locale: vi');
+      expect(console.warn).toHaveBeenCalledWith('Missing locale: uz');
     });
   });
 


### PR DESCRIPTION
**Description:**

Adds the Uzbek (`uz`) locale to the i18n module. This mirrors the prior Vietnamese support change (#825) and touches the same three files:

- `src/i18n/lib.js` — adds `uz` to `supportedLocales`, the `@formatjs/intl-pluralrules` and `@formatjs/intl-relativetimeformat` locale-data imports for `uz`, and the `messagesShape` PropTypes entry.
- `src/i18n/countries.js` — registers the `i18n-iso-countries` `uz` locale so country names localize in Uzbek.
- `src/i18n/lib.test.js` — updates the "missing locales" warning count (16 → 17) and adds the `uz` assertion.

**Why:** Uzbek translations already exist for downstream MFEs in the openedx-translations pipeline, but `frontend-platform` does not yet recognize `uz` as an expected locale. As a result it logs a dev-mode `Unexpected locale: uz` warning, and plural-rules / relative-time formatting and localized country names fall back rather than using Uzbek data. The required FormatJS (`@formatjs/.../locale-data/uz`) and `i18n-iso-countries` (`langs/uz.json`) data already ship with the existing dependencies, so no dependency changes are needed.

**Testing:**

- `npm run test` for `src/i18n` passes locally (29/29).
- `eslint` passes on the changed files.

**Merge checklist:**

- [ ] Consider running your code modifications in the included example app within `frontend-platform`. This can be done by running `npm start` and opening http://local.openedx.io:8080.
- [ ] Consider testing your code modifications in another local micro-frontend using local aliases configured via [the `module.config.js` file in `frontend-build`](https://github.com/openedx/frontend-build#local-module-configuration-for-webpack).
- [x] Verify your commit title/body conforms to the conventional commits format (e.g., `fix`, `feat`) and is appropriate for your code change. Consider whether your code is a breaking change, and modify your commit accordingly.

**Post merge:**

- [ ] After the build finishes for the merged commit, verify the new release has been pushed to [NPM](https://www.npmjs.com/package/@edx/frontend-platform).

🤖 Generated with [Claude Code](https://claude.com/claude-code)